### PR TITLE
Do not use printf() to emit output

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -156,8 +156,7 @@ class Server
 
         $this->bufferLevel = null;
 
-        // Using printf so that we can override the function when testing
-        printf($response->getBody());
+        echo $response->getBody();
     }
 
     /**

--- a/test/TestAsset/Functions.php
+++ b/test/TestAsset/Functions.php
@@ -17,13 +17,44 @@
 
 namespace Phly\Http;
 
+
 /**
  * Store output artifacts
  */
-abstract class Output
+class HeaderStack
 {
-    public static $headers = array();
-    public static $body;
+    /**
+     * @var array
+     */
+    private static $data = array();
+
+    /**
+     * Reset state
+     */
+    public static function reset()
+    {
+        self::$data = array();
+    }
+
+    /**
+     * Push a header on the stack
+     *
+     * @param string $header
+     */
+    public static function push($header)
+    {
+        self::$data[] = $header;
+    }
+
+    /**
+     * Return the current header stack
+     *
+     * @return array
+     */
+    public static function stack()
+    {
+        return self::$data;
+    }
 }
 
 /**
@@ -43,15 +74,5 @@ function headers_sent()
  */
 function header($value)
 {
-    Output::$headers[] = $value;
-}
-
-/**
- * Emit some output, without creating actual output artifacts
- *
- * @param string $template
- */
-function printf($template)
-{
-    Output::$body = $template;
+    HeaderStack::push($value);
 }


### PR DESCRIPTION
- Raises errors if `%` symbols are present, as those are used to denote
  replacements... which MUST then be present as arguments. Do a straight
  `echo` instead.
- Required refactoring the test assets to:
  - remove `printf` overriding.
  - aggregate only headers; renamed `Output` to `HeaderStack`, and provided
    methods for pushing on to the stack, retrieving from it, and resetting it.
  - updating the tests to use `expectOutputString()` and to refer to
    `HeaderStack::stack()` when testing against headers.

Fixes an issue observed when some HTML being emitted included "100%" in an 
attribute.
