### PR TITLE
PhlyTest namespace in autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,13 @@
   },
   "autoload": {
     "psr-4": {
-      "Phly\\Http\\": "src/",
-      "PhlyTest\\Http\\": "test/"
+      "Phly\\Http\\": "src/"
     }
   },
   "autoload-dev": {
+    "psr-4": {
+      "PhlyTest\\Http\\": "test/"
+    },
     "files": [
       "test/TestAsset/Functions.php"
     ]


### PR DESCRIPTION
Hello. I want to include this project in [my list of lightweight libraries](https://github.com/jm42/lightweight-php), but it has something that I find problematic to calculate the "weight" of this projects.

The test namespace is included in the autoload configuration, always. See, I use the directories in the autoload configuration of composer to know which are the _source_ folders to parse and calculate the "weight".

Since I think the test namespace will be only used when the dev requirements have been installed it seems like a plausible change.
