### PR TITLE
Allow empty paths

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -404,7 +404,7 @@ class Uri implements UriTargetInterface
             );
         }
 
-        if (strpos($path, '/') !== 0) {
+        if (! empty($path) && strpos($path, '/') !== 0) {
             $path = '/' . $path;
         }
 

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -345,4 +345,11 @@ class UriTest extends TestCase
         $uri = new Uri('*');
         $this->assertEquals('*', (string) $uri);
     }
+
+    public function testCanUseAnEmptyPath()
+    {
+        $uri = new Uri('http://example.com/foo');
+        $new = $uri->withPath('');
+        $this->assertEquals('', $new->getPath());
+    }
 }


### PR DESCRIPTION
Paths can be empty. However, previously, a check for the first character not
being a slash always prepended a slash -- even when the path was empty.

This fixes phly/conduit#27