### PR TITLE
Empty path == "/" for origin-form and absolute-form targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.8.4 - TBD
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#23](https://github.com/phly/http/pull/24) and [#24](https://github.com/phly/http/pull/24)
+  detailed several use cases where empty paths and root paths were not being
+  represented correctly. The correct, normalized form of an origin-form or
+  absolute-form request-target is that an empty path should be represented by a
+  "/". As of this release, this is now correct.
+
 ## 0.8.3 - 2015-01-21
 
 ### Added

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -97,7 +97,7 @@ class Uri implements UriTargetInterface
         return self::createUriString(
             $this->scheme,
             $this->getAuthority(),
-            $this->path,
+            $this->getPath(), // Absolute URIs should use a "/" for an empty path
             $this->query,
             $this->fragment
         );
@@ -212,10 +212,19 @@ class Uri implements UriTargetInterface
      * This method MUST return a string; if no path is present it MUST return
      * an empty string.
      *
+     * If the instance represents an absolute- or origin-form, and the path is
+     * empty, this method MUST return "/".
+     *
      * @return string The path segment of the URI.
      */
     public function getPath()
     {
+        if (empty($this->path)
+            && ($this->isOrigin() || $this->isAbsolute())
+        ) {
+            return '/';
+        }
+
         return $this->path;
     }
 

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -346,10 +346,72 @@ class UriTest extends TestCase
         $this->assertEquals('*', (string) $uri);
     }
 
-    public function testCanUseAnEmptyPath()
+    public function nonAbsoluteTargetsWithEmptyPaths()
+    {
+        return [
+            'host-only'        => [ [ 'host' => 'api.example.com' ] ],
+            'host-query'       => [ [ 'host' => 'api.example.com', 'query' => 'foo=bar' ] ],
+            'host-port'        => [ [ 'host' => 'api.example.com', 'port' => 80 ] ],
+            'host-port-query'  => [ [ 'host' => 'api.example.com', 'port' => 80, 'query' => 'foo=bar' ] ],
+            'user-host'        => [ [ 'user-info' => 'matthew', 'host' => 'api.example.com' ] ],
+            'user-host-query'  => [ [ 'user-info' => 'matthew', 'host' => 'api.example.com', 'query' => 'foo=bar' ] ],
+            'authority'        => [ [ 'user-info' => 'matthew', 'host' => 'api.example.com', 'port' => 80 ] ],
+            'authority-query'  => [ [
+                'user-info' => 'matthew',
+                'host'      => 'api.example.com',
+                'port'      => 80,
+                'query'     => 'foo=bar',
+            ] ],
+        ];
+    }
+
+    /**
+     * @dataProvider nonAbsoluteTargetsWithEmptyPaths
+     */
+    public function testCanUseAnEmptyPathWithANonUriTargets(array $parts)
+    {
+        $uri = new Uri();
+        foreach ($parts as $type => $value) {
+            switch ($type) {
+                case 'user-info':
+                    $uri = $uri->withUserInfo($value);
+                    break;
+                case 'host':
+                    $uri = $uri->withHost($value);
+                    break;
+                case 'port':
+                    $uri = $uri->withPort($value);
+                    break;
+                case 'query':
+                    $uri = $uri->withQuery($value);
+                    break;
+            }
+        }
+        $this->assertEquals('', $uri->getPath());
+    }
+
+    public function testSettingEmptyPathOnAbsoluteUriIsEquivalentToSettingRootPath()
     {
         $uri = new Uri('http://example.com/foo');
         $new = $uri->withPath('');
-        $this->assertEquals('', $new->getPath());
+        $this->assertEquals('/', $new->getPath());
+    }
+
+    public function testStringRepresentationOfAbsoluteUriWithNoPathNormalizesPath()
+    {
+        $uri = new Uri('http://example.com');
+        $this->assertEquals('http://example.com/', (string) $uri);
+    }
+
+    public function testEmptyPathOnOriginFormIsEquivalentToRootPath()
+    {
+        $uri = new Uri('?foo=bar');
+        $this->assertEquals('/', $uri->getPath());
+    }
+
+    public function testStringRepresentationOfOriginFormWithNoPathNormalizesPath()
+    {
+        $uri = new Uri('?foo=bar');
+        $this->assertEquals('/?foo=bar', (string) $uri);
     }
 }


### PR DESCRIPTION
Per #23 and #24, request-targets that represent either origin-form or absolute-form should never allow empty paths; an empty path is equivalent to the root path, "/".