### PR TITLE
Updated listen() to follow Conduit semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ $server->listen();
 At this time, you can optionally provide a callback to `listen()`; this will be passed to the handler as the third argument (`$done`):
 
 ```php
-$server->listen(function ($error = null) {
+$server->listen(function ($request, $response, $error = null) {
     if (! $error) {
         return;
     }
@@ -187,7 +187,9 @@ $server->listen(function ($error = null) {
 });
 ```
 
-Typically, the `listen` callback will be an error handler, and can expect to receive the error as its argument.
+Typically, the `listen` callback will be an error handler, and can expect to
+receive the request, response, and error as its arguments (though the error may
+be null).
 
 API
 ---


### PR DESCRIPTION
With the change to Conduit's Next invokable, the callback to
`Server::listen()` needs to have the signature `function ($request,
$response, $error = null)` in order to be valid.

Interestingly, there was never a test for this functionality, though the
previous signature was documented.