### PR TITLE
Ensure the request target gets recalculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.10.1 - TBD
+
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- A patch was added to ensure the request-target is always recalculated if not
+  set explicitly.
+
 ## 0.10.0 - 2015-01-28
 
 This release is backwards incompatible with 0.9.X. It updates its

--- a/src/Request.php
+++ b/src/Request.php
@@ -110,16 +110,15 @@ class Request implements RequestInterface
         }
 
         if (! $this->uri) {
-            $this->requestTarget = '/';
-            return $this->requestTarget;
+            return '/';
         }
 
-        $this->requestTarget = $this->uri->getPath();
+        $target = $this->uri->getPath();
         if ($this->uri->getQuery()) {
-            $this->requestTarget .= '?' . $this->uri->getQuery();
+            $target .= '?' . $this->uri->getQuery();
         }
 
-        return $this->requestTarget;
+        return $target;
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -241,4 +241,19 @@ class RequestTest extends TestCase
         $this->setExpectedException('InvalidArgumentException', 'Invalid request target');
         $request->withRequestTarget('foo bar baz');
     }
+
+    public function testRequestTargetDoesNotCacheBetweenInstances()
+    {
+        $request = (new Request())->withUri(new Uri('https://example.com/foo/bar'));
+        $original = $request->getRequestTarget();
+        $newRequest = $request->withUri(new Uri('http://mwop.net/bar/baz'));
+        $this->assertNotEquals($original, $newRequest->getRequestTarget());
+    }
+
+    public function testSettingNewUriResetsRequestTarget()
+    {
+        $request = (new Request())->withUri(new Uri('https://example.com/foo/bar'));
+        $original = $request->getRequestTarget();
+        $newRequest = $request->withUri(new Uri('http://mwop.net/bar/baz'));
+    }
 }


### PR DESCRIPTION
When a new URI is present, the request target should be recalculated
(unless a request-target was explicitly set).