### PR TITLE
Updates to psr/http-message 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.11.0 - TBD
+
+This release contains one backwards incompatible change. The upstream
+psr/http-message's `ServerRequestInterface` renamed the following methods:
+
+- `getBodyParams()` was renamed to `getParsedBody()`.
+- `withBodyParams()` was renamed to `withParsedBody()`.
+
+Additionally, `withParsedBody()` removes the `array` typehint.
+
+### Added
+
+- `Phly\Http\ServerRequest::getParsedBody()` (replaces `getBodyParams()`)
+- `Phly\Http\ServerRequest::withParsedBody()` (replaces `getBodyParams()`)
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `Phly\Http\ServerRequest::getBodyParams()` (replaced with `getParsedBody()`)
+- `Phly\Http\ServerRequest::withBodyParams()` (replaced with `getParsedBody()`)
+
+### Fixed
+
+- `Phly\Http\ServerRequestFactory` was updated to call `withParsedBody()` when
+  seeding parsed body data.
+
 ## 0.10.2 - 2015-02-11
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "psr/http-message": "~0.8.0"
+    "psr/http-message": "dev-feature/parsed-body@dev"
   },
   "require-dev": {
     "phpunit/PHPUnit": "3.7.*",
@@ -44,5 +44,11 @@
     "files": [
       "test/TestAsset/Functions.php"
     ]
-  }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/weierophinney/http-message.git"
+    }
+  ]
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -29,17 +29,17 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @var array
      */
-    private $bodyParams;
-
-    /**
-     * @var array
-     */
     private $cookieParams;
 
     /**
      * @var array
      */
     private $fileParams;
+
+    /**
+     * @var array
+     */
+    private $parsedBody;
 
     /**
      * @var array
@@ -190,38 +190,52 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * Retrieve any parameters provided in the request body.
      *
-     * If the request body can be deserialized to an array, this method MAY be
-     * used to retrieve them.
+     * If the request Content-Type is application/x-www-form-urlencoded and the
+     * request method is POST, this method MUST return the contents of $_POST.
      *
-     * @return array The deserialized body parameters, if any.
+     * Otherwise, this method may return any results of deserializing
+     * the request body content; as parsing returns structured content, the
+     * potential types MUST be arrays or objects only. A null value indicates
+     * the absence of body content.
+     *
+     * @return null|array|object The deserialized body parameters, if any.
+     *     These will typically be an array or object.
      */
-    public function getBodyParams()
+    public function getParsedBody()
     {
-        return $this->bodyParams;
+        return $this->parsedBody;
     }
 
     /**
      * Create a new instance with the specified body parameters.
      *
-     * These MAY be injected during instantiation from PHP's $_POST
-     * superglobal. The data IS NOT REQUIRED to come from $_POST, but MUST be
-     * an array. This method can be used during the request lifetime to inject
-     * parameters discovered and/or deserialized from the request body; as an
-     * example, if content negotiation determines that the request data is
-     * a JSON payload, this method could be used to inject the deserialized
-     * parameters.
+     * These MAY be injected during instantiation.
+     *
+     * If the request Content-Type is application/x-www-form-urlencoded and the
+     * request method is POST, use this method ONLY to inject the contents of
+     * $_POST.
+     *
+     * The data IS NOT REQUIRED to come from $_POST, but MUST be the results of
+     * deserializing the request body content. Deserialization/parsing returns
+     * structured data, and, as such, this method ONLY accepts arrays or objects,
+     * or a null value if nothing was available to parse.
+     *
+     * As an example, if content negotiation determines that the request data
+     * is a JSON payload, this method could be used to create a request
+     * instance with the deserialized parameters.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return a new instance that has the
      * updated body parameters.
      *
-     * @param array $params The deserialized body parameters.
+     * @param null|array|object $data The deserialized body data. This will
+     *     typically be in an array or object.
      * @return self
      */
-    public function withBodyParams(array $params)
+    public function withParsedBody($data)
     {
         $new = clone $this;
-        $new->bodyParams = $params;
+        $new->parsedBody = $data;
         return $new;
     }
 

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -61,7 +61,7 @@ abstract class ServerRequestFactory
         return $request
             ->withCookieParams($cookies ?: $_COOKIE)
             ->withQueryParams($query ?: $_GET)
-            ->withBodyParams($body ?: $_POST);
+            ->withParsedBody($body ?: $_POST);
     }
 
     /**

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -351,7 +351,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertInstanceOf('Phly\Http\ServerRequest', $request);
         $this->assertEquals($cookies, $request->getCookieParams());
         $this->assertEquals($query, $request->getQueryParams());
-        $this->assertEquals($body, $request->getBodyParams());
+        $this->assertEquals($body, $request->getParsedBody());
         $this->assertEquals($files, $request->getFileParams());
         $this->assertEmpty($request->getAttributes());
     }

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -49,17 +49,17 @@ class ServerRequestTest extends TestCase
         $this->assertEmpty($this->request->getFileParams());
     }
 
-    public function testBodyParamsAreEmptyByDefault()
+    public function testParsedBodyIsEmptyByDefault()
     {
-        $this->assertEmpty($this->request->getBodyParams());
+        $this->assertEmpty($this->request->getParsedBody());
     }
 
-    public function testBodyParamsMutatorReturnsCloneWithChanges()
+    public function testParsedBodyMutatorReturnsCloneWithChanges()
     {
         $value = ['foo' => 'bar'];
-        $request = $this->request->withBodyParams($value);
+        $request = $this->request->withParsedBody($value);
         $this->assertNotSame($this->request, $request);
-        $this->assertEquals($value, $request->getBodyParams());
+        $this->assertEquals($value, $request->getParsedBody());
     }
 
     public function testAttributesAreEmptyByDefault()


### PR DESCRIPTION
Updates to follow the latest changes to psr/http-message, which involves renaming "BodyParams" to "ParsedBody", and removing the `array` typehint from `withParsedBody()`.