### PR TITLE
Switched InvalidArgumentException for OutOfRangeException

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -2,6 +2,7 @@
 namespace Phly\Http;
 
 use InvalidArgumentException;
+use OutOfRangeException;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -342,7 +343,8 @@ class Uri implements UriInterface
      * @param null|int $port Port to use with the new instance; a null value
      *     removes the port information.
      * @return self A new instance with the specified port.
-     * @throws InvalidArgumentException for invalid ports.
+     * @throws InvalidArgumentException for invalid data types.
+     * @throws OutOfRangeException if port is not in the valid range.
      */
     public function withPort($port)
     {
@@ -356,7 +358,7 @@ class Uri implements UriInterface
         $port = (int) $port;
 
         if ($port < 1 || $port > 65535) {
-            throw new InvalidArgumentException(sprintf(
+            throw new OutOfRangeException(sprintf(
                 'Invalid port "%d" specified; must be a valid TCP/UDP port',
                 $port
             ));

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -79,10 +79,7 @@ class UriTest extends TestCase
             'false'     => [ false ],
             'string'    => [ 'string' ],
             'array'     => [ [ 3000 ] ],
-            'object'    => [ (object) [ 3000 ] ],
-            'zero'      => [ 0 ],
-            'too-small' => [ -1 ],
-            'too-big'   => [ 65536 ],
+            'object'    => [ (object) [ 3000 ] ]
         ];
     }
 
@@ -93,6 +90,25 @@ class UriTest extends TestCase
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $this->setExpectedException('InvalidArgumentException', 'Invalid port');
+        $new = $uri->withPort($port);
+    }
+
+    public function badRangePorts()
+    {
+        return [
+            'too-small' => [ -1 ],
+            'too-big'   => [ 65536 ],
+            'zero'      => [ 0 ]
+        ];
+    }
+
+    /**
+     * @dataProvider badRangePorts
+     */
+    public function testWithPortRaisesExceptionForInvalidPortRanges($port)
+    {
+        $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
+        $this->setExpectedException('OutOfRangeException', 'Invalid port');
         $new = $uri->withPort($port);
     }
 


### PR DESCRIPTION
Switched `InvalidArgumentException` with `OutOfRangeException` in `Phly\Http\Uri::withPort()`. The purpose of the later exception is to indicate that the exception is not within a valid range. I think it makes it more natural than invalid argument is a bit ambiguous IMO.