### PR TITLE
Fix the usage of numeric string Uri ports

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -346,7 +346,7 @@ class Uri implements UriInterface
      */
     public function withPort($port)
     {
-        if (! is_integer($port) || (is_string($port) && ! is_numeric($port))) {
+        if (!(is_integer($port) || (is_string($port) && is_numeric($port)))) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid port "%s" specified; must be an integer or integer string',
                 (is_object($port) ? get_class($port) : gettype($port))

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -62,13 +62,24 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@framework.zend.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    public function testWithPortReturnsNewInstanceWithProvidedPort()
+    public function validPorts()
+    {
+        return [
+            'int'       => [ 3000 ],
+            'string'    => [ "3000" ]
+        ];
+    }
+
+    /**
+     * @dataProvider validPorts
+     */
+    public function testWithPortReturnsNewInstanceWithProvidedPort($port)
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
-        $new = $uri->withPort(3000);
+        $new = $uri->withPort($port);
         $this->assertNotSame($uri, $new);
-        $this->assertEquals(3000, $new->getPort());
-        $this->assertEquals('https://user:pass@local.example.com:3000/foo?bar=baz#quz', (string) $new);
+        $this->assertEquals($port, $new->getPort());
+        $this->assertEquals('https://user:pass@local.example.com:'.$port.'/foo?bar=baz#quz', (string) $new);
     }
 
     public function invalidPorts()


### PR DESCRIPTION
In the current release using a numeric string for the Uri port throws an Exception. This fix checks correctly the Uri port in the method `withPort`