### PR TITLE
[Stream] Determine stream size

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -128,7 +128,12 @@ class Stream implements StreamableInterface
      */
     public function getSize()
     {
-        return null;
+        if (null === $this->resource) {
+            return null;
+        }
+
+        $stats = fstat($this->resource);
+        return $stats['size'];
     }
 
     /**

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -107,8 +107,12 @@ class StreamTest extends TestCase
         $this->assertSame($resource, $detached);
     }
 
-    public function testSizeAlwaysReportsNull()
+    /**
+     * @group 42
+     */
+    public function testSizeReportsNullWhenNoResourcePresent()
     {
+        $this->stream->detach();
         $this->assertNull($this->stream->getSize());
     }
 
@@ -399,5 +403,16 @@ class StreamTest extends TestCase
         $this->stream->attach($resource);
 
         $this->assertNull($this->stream->getMetadata('TOTALLY_MADE_UP'));
+    }
+
+    /**
+     * @group 42
+     */
+    public function testGetSizeReturnsStreamSize()
+    {
+        $resource = fopen(__FILE__, 'r');
+        $expected = fstat($resource);
+        $stream = new Stream($resource);
+        $this->assertEquals($expected['size'], $stream->getSize());
     }
 }


### PR DESCRIPTION
Hey!

I'm currently integrating your library in egeloen/ivory-http-adapter#74 and I have noticed the `Stream::getSize` always return `null`. Is it intended?