### PR TITLE
Update host when URI is set?

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -17,14 +17,14 @@ trait MessageTrait
      *
      * @var array
      */
-    private $headers = [];
+    protected $headers = [];
 
     /**
      * Map of normalized header name to original name used to register header.
      *
      * @var array
      */
-    private $headerNames = [];
+    protected $headerNames = [];
 
     /**
      * @var string

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,11 +1,7 @@
 <?php
 namespace Phly\Http;
 
-use InvalidArgumentException;
-use RuntimeException;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamableInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP Request encapsulation
@@ -16,41 +12,7 @@ use Psr\Http\Message\UriInterface;
  */
 class Request implements RequestInterface
 {
-    use MessageTrait;
-
-    /**
-     * @var string
-     */
-    private $method;
-
-    /**
-     * The request-target, if it has been provided or calculated.
-     *
-     * @var null|string
-     */
-    private $requestTarget;
-
-    /**
-     * @var null|UriInterface
-     */
-    private $uri;
-
-    /**
-     * Supported HTTP methods
-     *
-     * @var array
-     */
-    private $validMethods = [
-        'CONNECT',
-        'DELETE',
-        'GET',
-        'HEAD',
-        'OPTIONS',
-        'PATCH',
-        'POST',
-        'PUT',
-        'TRACE',
-    ];
+    use MessageTrait, RequestTrait;
 
     /**
      * @param null|string $uri URI for the request, if any.
@@ -61,189 +23,69 @@ class Request implements RequestInterface
      */
     public function __construct($uri = null, $method = null, $body = 'php://memory', array $headers = [])
     {
-        if (! $uri instanceof UriInterface && ! is_string($uri) && null !== $uri) {
-            throw new InvalidArgumentException(
-                'Invalid URI provided; must be null, a string, or a Psr\Http\Message\UriInterface instance'
-            );
-        }
-
-        $this->validateMethod($method);
-
-        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamableInterface) {
-            throw new InvalidArgumentException(
-                'Body must be a string stream resource identifier, '
-                . 'an actual stream resource, '
-                . 'or a Psr\Http\Message\StreamableInterface implementation'
-            );
-        }
-
-        if (is_string($uri)) {
-            $uri = new Uri($uri);
-        }
-
-        $this->method = $method;
-        $this->uri    = $uri;
-        $this->stream = ($body instanceof StreamableInterface) ? $body : new Stream($body, 'r');
-
-        list($this->headerNames, $this->headers) = $this->filterHeaders($headers);
+        $this->initialize($uri, $method, $body, $headers);
     }
 
     /**
-     * Retrieves the message's request target.
+     * Extends MessageInterface::getHeaders() to provide request-specific
+     * behavior.
      *
-     * Retrieves the message's request-target either as it will appear (for
-     * clients), as it appeared at request (for servers), or as it was
-     * specified for the instance (see withRequestTarget()).
+     * Retrieves all message headers.
      *
-     * In most cases, this will be the origin-form of the composed URI,
-     * unless a value was provided to the concrete implementation (see
-     * withRequestTarget() below).
+     * This method acts exactly like MessageInterface::getHeaders(), with one
+     * behavioral change: if the Host header has not been previously set, the
+     * method MUST attempt to pull the host segment of the composed URI, if
+     * present.
      *
-     * If no URI is available, and no request-target has been specifically
-     * provided, this method MUST return the string "/".
-     *
-     * @return string
+     * @see MessageInterface::getHeaders()
+     * @see UriInterface::getHost()
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings.
      */
-    public function getRequestTarget()
+    public function getHeaders()
     {
-        if (null !== $this->requestTarget) {
-            return $this->requestTarget;
+        $headers = $this->headers;
+        if (! $this->hasHeader('host')
+            && ($this->uri && $this->uri->getHost())
+        ) {
+            $headers['Host'] = [$this->getHostFromUri()];
         }
 
-        if (! $this->uri) {
-            return '/';
-        }
-
-        $target = $this->uri->getPath();
-        if ($this->uri->getQuery()) {
-            $target .= '?' . $this->uri->getQuery();
-        }
-
-        return $target;
+        return $headers;
     }
 
     /**
-     * Create a new instance with a specific request-target.
+     * Extends MessageInterface::getHeaderLines() to provide request-specific
+     * behavior.
      *
-     * If the request needs a non-origin-form request-target — e.g., for
-     * specifying an absolute-form, authority-form, or asterisk-form —
-     * this method may be used to create an instance with the specified
-     * request-target, verbatim.
+     * Retrieves a header by the given case-insensitive name as an array of strings.
      *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * changed request target.
+     * This method acts exactly like MessageInterface::getHeaderLines(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method MUST attempt to pull the host
+     * segment of the composed URI, if present.
      *
-     * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
-     *     request-target forms allowed in request messages)
-     * @param mixed $requestTarget
-     * @return self
-     * @throws InvalidArgumentException if the request target is invalid.
+     * @see MessageInterface::getHeaderLines()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string[]
      */
-    public function withRequestTarget($requestTarget)
+    public function getHeaderLines($header)
     {
-        if (preg_match('#\s#', $requestTarget)) {
-            throw new InvalidArgumentException(
-                'Invalid request target provided; cannot contain whitespace'
-            );
+        if (! $this->hasHeader($header)) {
+            if (strtolower($header) === 'host'
+                && ($this->uri && $this->uri->getHost())
+            ) {
+                return [$this->getHostFromUri()];
+            }
+
+            return [];
         }
 
-        $new = clone $this;
-        $new->requestTarget = $requestTarget;
-        return $new;
-    }
+        $header = $this->headerNames[strtolower($header)];
 
-    /**
-     * Retrieves the HTTP method of the request.
-     *
-     * @return string Returns the request method.
-     */
-    public function getMethod()
-    {
-        return $this->method;
-    }
-
-    /**
-     * Create a new instance with the provided HTTP method.
-     *
-     * While HTTP method names are typically all uppercase characters, HTTP
-     * method names are case-sensitive and thus implementations SHOULD NOT
-     * modify the given string.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * changed request method.
-     *
-     * @param string $method Case-insensitive method.
-     * @return self
-     * @throws InvalidArgumentException for invalid HTTP methods.
-     */
-    public function withMethod($method)
-    {
-        $this->validateMethod($method);
-        $new = clone $this;
-        $new->method = $method;
-        return $new;
-    }
-
-    /**
-     * Retrieves the URI instance.
-     *
-     * This method MUST return a UriInterface instance.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return UriInterface Returns a UriInterface instance
-     *     representing the URI of the request, if any.
-     */
-    public function getUri()
-    {
-        return $this->uri;
-    }
-
-    /**
-     * Create a new instance with the provided URI.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * new UriInterface instance.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param UriInterface $uri New request URI to use.
-     * @return self
-     */
-    public function withUri(UriInterface $uri)
-    {
-        $new = clone $this;
-        $new->uri = $uri;
-        return $new;
-    }
-
-    /**
-     * Validate the HTTP method
-     *
-     * @param null|string $method
-     * @throws InvalidArgumentException on invalid HTTP method.
-     */
-    private function validateMethod($method)
-    {
-        if (null === $method) {
-            return true;
-        }
-
-        if (! is_string($method)) {
-            throw new InvalidArgumentException(sprintf(
-                'Unsupported HTTP method; must be a string, received %s',
-                (is_object($method) ? get_class($method) : gettype($method))
-            ));
-        }
-
-        $method = strtoupper($method);
-
-        if (! in_array($method, $this->validMethods, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Unsupported HTTP method "%s" provided',
-                $method
-            ));
-        }
+        $value = $this->headers[$header];
+        $value = is_array($value) ? $value : [$value];
+        return $value;
     }
 }

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -1,0 +1,265 @@
+<?php
+namespace Phly\Http;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Trait with common request behaviors.
+ *
+ * Server and client-side requests differ slightly in how the Host header is
+ * handled; on client-side, it should be calculated on-the-fly from the
+ * composed URI (if present), while on server-side, it will be calculated from
+ * the enviornment. As such, this trait exists to provide the common code
+ * between both client-side and server-side requests, and each can then
+ * use the headers functionality required by their implementations.
+ */
+trait RequestTrait
+{
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * The request-target, if it has been provided or calculated.
+     *
+     * @var null|string
+     */
+    private $requestTarget;
+
+    /**
+     * @var null|UriInterface
+     */
+    private $uri;
+
+    /**
+     * Supported HTTP methods
+     *
+     * @var array
+     */
+    private $validMethods = [
+        'CONNECT',
+        'DELETE',
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'PATCH',
+        'POST',
+        'PUT',
+        'TRACE',
+    ];
+
+    /**
+     * Initialize request state.
+     *
+     * Used by constructors.
+     *
+     * @param null|string $uri URI for the request, if any.
+     * @param null|string $method HTTP method for the request, if any.
+     * @param string|resource|StreamableInterface $body Message body, if any.
+     * @param array $headers Headers for the message, if any.
+     * @throws InvalidArgumentException for any invalid value.
+     */
+    private function initialize($uri = null, $method = null, $body = 'php://memory', array $headers = [])
+    {
+        if (! $uri instanceof UriInterface && ! is_string($uri) && null !== $uri) {
+            throw new InvalidArgumentException(
+                'Invalid URI provided; must be null, a string, or a Psr\Http\Message\UriInterface instance'
+            );
+        }
+
+        $this->validateMethod($method);
+
+        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamableInterface) {
+            throw new InvalidArgumentException(
+                'Body must be a string stream resource identifier, '
+                . 'an actual stream resource, '
+                . 'or a Psr\Http\Message\StreamableInterface implementation'
+            );
+        }
+
+        if (is_string($uri)) {
+            $uri = new Uri($uri);
+        }
+
+        $this->method = $method;
+        $this->uri    = $uri;
+        $this->stream = ($body instanceof StreamableInterface) ? $body : new Stream($body, 'r');
+
+        list($this->headerNames, $this->headers) = $this->filterHeaders($headers);
+    }
+
+    /**
+     * Retrieves the message's request target.
+     *
+     * Retrieves the message's request-target either as it will appear (for
+     * clients), as it appeared at request (for servers), or as it was
+     * specified for the instance (see withRequestTarget()).
+     *
+     * In most cases, this will be the origin-form of the composed URI,
+     * unless a value was provided to the concrete implementation (see
+     * withRequestTarget() below).
+     *
+     * If no URI is available, and no request-target has been specifically
+     * provided, this method MUST return the string "/".
+     *
+     * @return string
+     */
+    public function getRequestTarget()
+    {
+        if (null !== $this->requestTarget) {
+            return $this->requestTarget;
+        }
+
+        if (! $this->uri) {
+            return '/';
+        }
+
+        $target = $this->uri->getPath();
+        if ($this->uri->getQuery()) {
+            $target .= '?' . $this->uri->getQuery();
+        }
+
+        return $target;
+    }
+
+    /**
+     * Create a new instance with a specific request-target.
+     *
+     * If the request needs a non-origin-form request-target — e.g., for
+     * specifying an absolute-form, authority-form, or asterisk-form —
+     * this method may be used to create an instance with the specified
+     * request-target, verbatim.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * changed request target.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
+     *     request-target forms allowed in request messages)
+     * @param mixed $requestTarget
+     * @return self
+     * @throws InvalidArgumentException if the request target is invalid.
+     */
+    public function withRequestTarget($requestTarget)
+    {
+        if (preg_match('#\s#', $requestTarget)) {
+            throw new InvalidArgumentException(
+                'Invalid request target provided; cannot contain whitespace'
+            );
+        }
+
+        $new = clone $this;
+        $new->requestTarget = $requestTarget;
+        return $new;
+    }
+
+    /**
+     * Retrieves the HTTP method of the request.
+     *
+     * @return string Returns the request method.
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * Create a new instance with the provided HTTP method.
+     *
+     * While HTTP method names are typically all uppercase characters, HTTP
+     * method names are case-sensitive and thus implementations SHOULD NOT
+     * modify the given string.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * changed request method.
+     *
+     * @param string $method Case-insensitive method.
+     * @return self
+     * @throws InvalidArgumentException for invalid HTTP methods.
+     */
+    public function withMethod($method)
+    {
+        $this->validateMethod($method);
+        $new = clone $this;
+        $new->method = $method;
+        return $new;
+    }
+
+    /**
+     * Retrieves the URI instance.
+     *
+     * This method MUST return a UriInterface instance.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @return UriInterface Returns a UriInterface instance
+     *     representing the URI of the request, if any.
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Create a new instance with the provided URI.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new UriInterface instance.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @param UriInterface $uri New request URI to use.
+     * @return self
+     */
+    public function withUri(UriInterface $uri)
+    {
+        $new = clone $this;
+        $new->uri = $uri;
+        return $new;
+    }
+
+    /**
+     * Validate the HTTP method
+     *
+     * @param null|string $method
+     * @throws InvalidArgumentException on invalid HTTP method.
+     */
+    private function validateMethod($method)
+    {
+        if (null === $method) {
+            return true;
+        }
+
+        if (! is_string($method)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported HTTP method; must be a string, received %s',
+                (is_object($method) ? get_class($method) : gettype($method))
+            ));
+        }
+
+        $method = strtoupper($method);
+
+        if (! in_array($method, $this->validMethods, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported HTTP method "%s" provided',
+                $method
+            ));
+        }
+    }
+
+    /**
+     * Retrieve the host from the URI instance
+     * 
+     * @return string
+     */
+    private function getHostFromUri()
+    {
+        $host  = $this->uri->getHost();
+        $host .= $this->uri->getPort() ? ':' . $this->uri->getPort() : '';
+        return $host;
+    }
+}

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -19,8 +19,10 @@ use Psr\Http\Message\StreamableInterface;
  * implemented such that they retain the internal state of the current
  * message and return a new instance that contains the changed state.
  */
-class ServerRequest extends Request implements ServerRequestInterface
+class ServerRequest implements ServerRequestInterface
 {
+    use MessageTrait, RequestTrait;
+
     /**
      * @var array
      */
@@ -69,7 +71,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         array $headers = []
     ) {
         $body = $this->getStream($body);
-        parent::__construct($uri, $method, $body, $headers);
+        $this->initialize($uri, $method, $body, $headers);
         $this->serverParams = $serverParams;
         $this->fileParams   = $fileParams;
     }
@@ -337,11 +339,10 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public function getMethod()
     {
-        $method = parent::getMethod();
-        if (empty ($method)) {
+        if (empty($this->method)) {
             return 'GET';
         }
-        return $method;
+        return $this->method;
     }
 
     /**
@@ -358,7 +359,10 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public function withMethod($method)
     {
-        return parent::withMethod(strtoupper($method));
+        $this->validateMethod($method);
+        $new = clone $this;
+        $new->method = $method;
+        return $new;
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -76,7 +76,11 @@ class RequestTest extends TestCase
         $this->assertSame($uri, $request->getUri());
         $this->assertEquals('POST', $request->getMethod());
         $this->assertSame($body, $request->getBody());
-        $this->assertEquals($headers, $request->getHeaders());
+        $testHeaders = $request->getHeaders();
+        foreach ($headers as $key => $value) {
+            $this->assertArrayHasKey($key, $testHeaders);
+            $this->assertEquals($value, $testHeaders[$key]);
+        }
     }
 
     public function invalidRequestUri()
@@ -255,5 +259,94 @@ class RequestTest extends TestCase
         $request = (new Request())->withUri(new Uri('https://example.com/foo/bar'));
         $original = $request->getRequestTarget();
         $newRequest = $request->withUri(new Uri('http://mwop.net/bar/baz'));
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHeadersContainsHostHeaderIfUriWithHostIsPresent()
+    {
+        $request = new Request('http://example.com');
+        $headers = $request->getHeaders();
+        $this->assertArrayHasKey('Host', $headers);
+        $this->assertContains('example.com', $headers['Host']);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHeadersContainsNoHostHeaderIfNoUriPresent()
+    {
+        $request = new Request();
+        $headers = $request->getHeaders();
+        $this->assertArrayNotHasKey('Host', $headers);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHeadersContainsNoHostHeaderIfUriDoesNotContainHost()
+    {
+        $request = new Request(new Uri());
+        $headers = $request->getHeaders();
+        $this->assertArrayNotHasKey('Host', $headers);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderReturnsUriHostWhenPresent()
+    {
+        $request = new Request('http://example.com');
+        $header = $request->getHeader('host');
+        $this->assertEquals('example.com', $header);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderReturnsNullIfNoUriPresent()
+    {
+        $request = new Request();
+        $this->assertNull($request->getHeader('host'));
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderReturnsNullIfUriDoesNotContainHost()
+    {
+        $request = new Request(new Uri());
+        $this->assertNull($request->getHeader('host'));
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderLinesReturnsUriHostWhenPresent()
+    {
+        $request = new Request('http://example.com');
+        $header = $request->getHeaderLines('host');
+        $this->assertContains('example.com', $header);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderLinesReturnsEmptyArrayIfNoUriPresent()
+    {
+        $request = new Request();
+        $header = $request->getHeaderLines('host');
+        $this->assertSame([], $header);
+    }
+
+    /**
+     * @group 39
+     */
+    public function testGetHostHeaderLinesReturnsEmptyArrayIfUriDoesNotContainHost()
+    {
+        $request = new Request(new Uri());
+        $header = $request->getHeaderLines('host');
+        $this->assertSame([], $header);
     }
 }


### PR DESCRIPTION
When implementing PSR-7, I was creating a client that used the headers of a message to send a request. All of my requests were failing because there was no Host header, which made me realize that the Host header of a request was not being updated when a URI is given to a request. I made this change to make consumers of a message not need to also check the URI for a host but can rather just rely on the headers provided by the request.

The logic I settled on was that when a URI is set on a request (whether in the constructor or withUri()), the Host header is updated to the host of the URI if it is present. I am opening this issue just to let you know and see if you wanted to make a similar change.