### PR TITLE
Filter query, path, and fragment in URIs?

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -91,13 +91,13 @@ class Uri implements UriInterface
             ));
         }
 
-        if (! empty($uri)) {
-            $this->parseUri($uri);
-        }
-
         $this->urlEncode = function (array $matches) {
             return rawurlencode($matches[0]);
         };
+
+        if (! empty($uri)) {
+            $this->parseUri($uri);
+        }
     }
 
     /**
@@ -569,9 +569,9 @@ class Uri implements UriInterface
         $this->userInfo  = isset($parts['user'])     ? $parts['user']     : '';
         $this->host      = isset($parts['host'])     ? $parts['host']     : '';
         $this->port      = isset($parts['port'])     ? $parts['port']     : null;
-        $this->path      = isset($parts['path'])     ? $parts['path']     : '';
-        $this->query     = isset($parts['query'])    ? $parts['query']    : '';
-        $this->fragment  = isset($parts['fragment']) ? $parts['fragment'] : '';
+        $this->path      = isset($parts['path'])     ? $this->filterPath($parts['path']) : '';
+        $this->query     = isset($parts['query'])    ? $this->filterQuery($parts['query']) : '';
+        $this->fragment  = isset($parts['fragment']) ? $this->filterFragment($parts['fragment']) : '';
 
         if (isset($parts['pass'])) {
             $this->userInfo .= ':' . $parts['pass'];

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -420,4 +420,72 @@ class UriTest extends TestCase
         $this->assertAttributeInternalType('null', 'uriString', $test);
         $this->assertAttributeEquals($string, 'uriString', $uri);
     }
+
+    /**
+     * @group 40
+     */
+    public function testPathIsProperlyEncoded()
+    {
+        $uri = (new Uri())->withPath('/foo^bar');
+        $expected = '/foo%5Ebar';
+        $this->assertEquals($expected, $uri->getPath());
+    }
+
+    public function testPathDoesNotBecomeDoubleEncoded()
+    {
+        $uri = (new Uri())->withPath('/foo%5Ebar');
+        $expected = '/foo%5Ebar';
+        $this->assertEquals($expected, $uri->getPath());
+    }
+
+    public function queryStringsForEncoding()
+    {
+        return [
+            'key-only' => ['k^ey', 'k%5Eey'],
+            'key-value' => ['k^ey=valu`', 'k%5Eey=valu%60'],
+            'array-key-only' => ['key[]', 'key%5B%5D'],
+            'array-key-value' => ['key[]=valu`', 'key%5B%5D=valu%60'],
+            'complex' => ['k^ey&key[]=valu`&f<>=`bar', 'k%5Eey&key%5B%5D=valu%60&f%3C%3E=%60bar'],
+        ];
+    }
+
+    /**
+     * @group 40
+     * @dataProvider queryStringsForEncoding
+     */
+    public function testQueryIsProperlyEncoded($query, $expected)
+    {
+        $uri = (new Uri())->withQuery($query);
+        $this->assertEquals($expected, $uri->getQuery());
+    }
+
+    /**
+     * @group 40
+     * @dataProvider queryStringsForEncoding
+     */
+    public function testQueryIsNotDoubleEncoded($query, $expected)
+    {
+        $uri = (new Uri())->withQuery($expected);
+        $this->assertEquals($expected, $uri->getQuery());
+    }
+
+    /**
+     * @group 40
+     */
+    public function testFragmentIsProperlyEncoded()
+    {
+        $uri = (new Uri())->withFragment('/p^th?key^=`bar#b@z');
+        $expected = '/p%5Eth?key%5E=%60bar%23b@z';
+        $this->assertEquals($expected, $uri->getFragment());
+    }
+
+    /**
+     * @group 40
+     */
+    public function testFragmentIsNotDoubleEncoded()
+    {
+        $expected = '/p%5Eth?key%5E=%60bar%23b@z';
+        $uri = (new Uri())->withFragment($expected);
+        $this->assertEquals($expected, $uri->getFragment());
+    }
 }


### PR DESCRIPTION
If this isn't already part of the spec, maybe it should be, but in my implementation, I'm percent encoding characters in the query, path, and fragment when they are set on a URI.

See: https://github.com/guzzle/psr7/blob/master/src/Uri.php#L491

(note: the regexes here are based on the regexes used in ZF2's URI filtering)