### PR TITLE
Uri object can't be serialized #53

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -72,13 +72,6 @@ class Uri implements UriInterface
     private $uriString;
 
     /**
-     * Function to urlencode the value returned by a regexp.
-     * 
-     * @var callable
-     */
-    private $urlEncode;
-
-    /**
      * @param string $uri
      * @throws InvalidArgumentException on non-string $uri argument
      */
@@ -90,10 +83,6 @@ class Uri implements UriInterface
                 (is_object($uri) ? get_class($uri) : gettype($uri))
             ));
         }
-
-        $this->urlEncode = function (array $matches) {
-            return rawurlencode($matches[0]);
-        };
 
         if (! empty($uri)) {
             $this->parseUri($uri);
@@ -658,7 +647,7 @@ class Uri implements UriInterface
 
         return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/',
-            $this->urlEncode,
+            [$this, 'encodeUrl'],
             $path
         );
     }
@@ -738,8 +727,18 @@ class Uri implements UriInterface
     {
         return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/',
-            $this->urlEncode,
+            [$this, 'encodeUrl'],
             $value
         );
+    }
+
+    /**
+     * Function to urlencode the value returned by a regexp.
+     * @param array $matches
+     * @return string
+     */
+    private function encodeUrl(array $matches)
+    {
+        return rawurlencode($matches[0]);
     }
 }


### PR DESCRIPTION
Steps to reproduce:

<?php

$uri = new Phly\Http\Uri('http://google.com/foo/bar');
serialize($uri);