### PR TITLE
Updated Uri to validate scheme when constructed.

### DIFF
--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -276,7 +276,16 @@ class UriTest extends TestCase
     /**
      * @dataProvider invalidSchemes
      */
-    public function testMutatingWithNonWebSchemeRaisesAnException($scheme)
+    public function testConstructWithUnsupportedSchemeRaisesAnException($scheme)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Unsupported scheme');
+        $uri = new Uri($scheme . '://example.com');
+    }
+
+    /**
+     * @dataProvider invalidSchemes
+     */
+    public function testMutatingWithUnsupportedSchemeRaisesAnException($scheme)
     {
         $uri = new Uri('http://example.com');
         $this->setExpectedException('InvalidArgumentException', 'Unsupported scheme');


### PR DESCRIPTION
Changed parseUri() to filter the scheme so a Uri cannot be constructed with an invalid scheme. The list of schemes can be modified by an extending class if an implementation wanted to support additional schemes.

Also altered getPort() to return null if the port was set to the standard port for the scheme.