### PR TITLE
Update to psr/http-message 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,74 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.12.0 - 2015-04-14
+
+This release is BACKWARDS IN-COMPATIBLE with previous releases. This is in large
+part due to massive changes between psr/http-message 0.9 and 0.10, which
+include:
+
+- Renaming `Psr\Http\Message\StreamableInterface` to
+  `Psr\Http\Message\StreamInterface`. This will not affect most consumers, but
+  it *does* change the signature of the `getBody()` and `withBody()` methods of
+  both requests and responses.
+- `Psr\Http\Message\UriInterface` now allows empty paths and relative paths,
+  which changes the behavior of `Uri::getPath()`.
+- `Psr\Http\Message\MessageInterface` renamed one method and changed the
+  behavior of another method with regard to headers:
+  - `getHeader($name)` now returns an array of values.
+  - `getHeaderLines($name)` was renamed to `getHeaderLine($name)`, and now
+    returns a string or `null`.
+- `Psr\Http\Message\StreamInterface` now uses exceptions for reporting error
+  conditions instead of multiple return values.
+- `Psr\Http\Message\RequestInterface::withUri()` defines an additional, optional
+  parameter, `$preserveHost`; when `true`, the message MUST NOT change the value
+  of the `Host` header; when `false`, it MUST change the value to correspond
+  with the value in the URI.
+- `Psr\Http\Message\ServerRequestInterface` renames `getFileUploads()` to
+  `getUploadedFiles()`, and adds a mutator method, `withFileUploads()`. The
+  structure of this property MUST be a tree with each leaf an instance of a new
+  interface, `Psr\Http\Message\UploadedFileInterface`.
+
+Due to the above changes, a number of changes were made to phly/http.
+
+### Added
+
+- `Phly\Http\UploadedFile`, which is an implementation of
+  `Psr\Http\Message\UploadedFileInterface`, and provides metadata around an
+  uploaded file, as well as behavior for retrieving a
+  `Psr\Http\Http\StreamInterface`  representing the upload and for moving the
+  file to its target destination in an SAPI-agnostic way.
+- `Phly\Http\ServerRequestFactory::normalizeFiles()`, which will normalize an
+  array of files to a tree of `Phly\Http\UploadedFile` instances, including
+  normalization of upload file arrays.
+- `Phly\Http\ServerRequest::getUploadedFiles()`, for returning the normalized
+  uploaded files tree.
+- `Phly\Http\ServerRequest::withUploadedFiles()`, for returning a new instance
+  containing the uploaded files.
+- `Phly\Http\Uri::getHeaderLine($name)`, which returns the comma-concatenated
+  values for the given header.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `Phly\Http\ServerRequest::getFileParams()`, which was replaced with the
+  `getUploadedFiles()` method.
+- `Phly\Http\Uri::getHeaderLines()`, which was renamed to `getHeaderLine()`,
+  with different behavior.
+
+### Fixed
+
+- `Phly\Http\Uri::withPath()` now defines and accepts the `$preserveHost`
+  argument, as outlined in this version's overview summary.
+- `Phly\Http\Uri::getHeader()` now returns an array of values associated with
+  the header; an empty array is returned if the header is not defined.
+- `Phly\Http\Stream` now raises `InvalidArgumentException` and
+  `RuntimeException` when unable to perform work, instead of overloading the
+  return value.
+
 ## 0.11.3 - 2015-04-13
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "psr/http-message": "^0.9"
+    "psr/http-message": "^0.10"
   },
   "require-dev": {
     "phpunit/PHPUnit": "3.7.*",

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -123,12 +123,15 @@ trait MessageTrait
      */
     public function getHeader($header)
     {
-        $value = $this->getHeaderLines($header);
-        if (! $value || empty($value)) {
-            return null;
+        if (! $this->hasHeader($header)) {
+            return [];
         }
 
-        return implode(',', $value);
+        $header = $this->headerNames[strtolower($header)];
+
+        $value = $this->headers[$header];
+        $value = is_array($value) ? $value : [$value];
+        return $value;
     }
 
     /**
@@ -153,15 +156,12 @@ trait MessageTrait
      */
     public function getHeaderLine($header)
     {
-        if (! $this->hasHeader($header)) {
-            return [];
+        $value = $this->getHeader($header);
+        if (empty($value)) {
+            return null;
         }
 
-        $header = $this->headerNames[strtolower($header)];
-
-        $value = $this->headers[$header];
-        $value = is_array($value) ? $value : [$value];
-        return $value;
+        return implode(',', $value);
     }
 
     /**

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -49,13 +49,13 @@ trait MessageTrait
     }
 
     /**
-     * Create a new instance with the specified HTTP protocol version.
+     * Return an instance with the specified HTTP protocol version.
      *
      * The version string MUST contain only the HTTP version number (e.g.,
      * "1.1", "1.0").
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new protocol version.
      *
      * @param string $version HTTP protocol version
@@ -108,18 +108,18 @@ trait MessageTrait
     }
 
     /**
-     * Retrieve a header by the given case-insensitive name, as a string.
+     * Retrieves a message header value by the given case-insensitive name.
      *
-     * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
+     * This method returns an array of all the header values of the given
+     * case-insensitive header name.
      *
-     * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeaderLines() instead
-     * and supply your own delimiter when concatenating.
+     * If the header does not appear in the message, this method MUST return an
+     * empty array.
      *
-     * @param string $header Case-insensitive header name.
-     * @return string|null Null is returned if no value exists.
+     * @param string $name Case-insensitive header field name.
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
      */
     public function getHeader($header)
     {
@@ -132,12 +132,26 @@ trait MessageTrait
     }
 
     /**
-     * Retrieves a header by the given case-insensitive name as an array of strings.
+     * Retrieves the line for a single header, with the header values as a
+     * comma-separated string.
      *
-     * @param string $header Case-insensitive header name.
-     * @return string[]
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
+     *
+     * NOTE: Not all header values may be appropriately represented using
+     * comma concatenation. For such headers, use getHeader() instead
+     * and supply your own delimiter when concatenating.
+     *
+     * If the header does not appear in the message, this method MUST return
+     * a null value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string|null A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return a null value.
      */
-    public function getHeaderLines($header)
+    public function getHeaderLine($header)
     {
         if (! $this->hasHeader($header)) {
             return [];
@@ -151,20 +165,20 @@ trait MessageTrait
     }
 
     /**
-     * Create a new instance with the provided header, replacing any existing
+     * Return an instance with the provided header, replacing any existing
      * values of any headers with the same case-insensitive name.
      *
-     * The header name is case-insensitive. The header values MUST be a string
-     * or an array of strings.
+     * While header names are case-insensitive, the casing of the header will
+     * be preserved by this function, and returned from getHeaders().
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new and/or updated header and value.
      *
-     * @param string $header Header name
+     * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
      * @return self
-     * @throws InvalidArgumentException for invalid header names or values.
+     * @throws \InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($header, $value)
     {
@@ -188,7 +202,7 @@ trait MessageTrait
     }
 
     /**
-     * Creates a new instance, with the specified header appended with the
+     * Return an instance with the specified header appended with the
      * given value.
      *
      * Existing values for the specified header will be maintained. The new
@@ -196,13 +210,13 @@ trait MessageTrait
      * exist previously, it will be added.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new header and/or value.
      *
-     * @param string $header Header name to add
+     * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
      * @return self
-     * @throws InvalidArgumentException for invalid header names or values.
+     * @throws \InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($header, $value)
     {
@@ -229,15 +243,15 @@ trait MessageTrait
     }
 
     /**
-     * Creates a new instance, without the specified header.
+     * Return an instance without the specified header.
      *
      * Header resolution MUST be done without case-sensitivity.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that removes
+     * immutability of the message, and MUST return an instance that removes
      * the named header.
      *
-     * @param string $header HTTP header to remove
+     * @param string $name Case-insensitive header field name to remove.
      * @return self
      */
     public function withoutHeader($header)
@@ -265,7 +279,7 @@ trait MessageTrait
     }
 
     /**
-     * Create a new instance, with the specified message body.
+     * Return an instance with the specified message body.
      *
      * The body MUST be a StreamInterface object.
      *
@@ -275,7 +289,7 @@ trait MessageTrait
      *
      * @param StreamInterface $body Body.
      * @return self
-     * @throws InvalidArgumentException When the body is not valid.
+     * @throws \InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)
     {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -2,7 +2,7 @@
 namespace Phly\Http;
 
 use InvalidArgumentException;
-use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Trait implementing the various methods defined in
@@ -32,7 +32,7 @@ trait MessageTrait
     private $protocol = '1.1';
 
     /**
-     * @var StreamableInterface
+     * @var StreamInterface
      */
     private $stream;
 
@@ -257,7 +257,7 @@ trait MessageTrait
     /**
      * Gets the body of the message.
      *
-     * @return StreamableInterface Returns the body as a stream.
+     * @return StreamInterface Returns the body as a stream.
      */
     public function getBody()
     {
@@ -267,17 +267,17 @@ trait MessageTrait
     /**
      * Create a new instance, with the specified message body.
      *
-     * The body MUST be a StreamableInterface object.
+     * The body MUST be a StreamInterface object.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return a new instance that has the
      * new body stream.
      *
-     * @param StreamableInterface $body Body.
+     * @param StreamInterface $body Body.
      * @return self
      * @throws InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamableInterface $body)
+    public function withBody(StreamInterface $body)
     {
         $new = clone $this;
         $new->stream = $body;

--- a/src/PhpInputStream.php
+++ b/src/PhpInputStream.php
@@ -27,6 +27,9 @@ class PhpInputStream extends Stream
         parent::__construct($stream, $mode);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         if ($this->reachedEof) {
@@ -37,11 +40,17 @@ class PhpInputStream extends Stream
         return $this->cache;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isWritable()
     {
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function read($length)
     {
         $content = parent::read($length);
@@ -56,6 +65,9 @@ class PhpInputStream extends Stream
         return $content;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getContents($maxLength = -1)
     {
         if ($this->reachedEof) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -27,20 +27,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Extends MessageInterface::getHeaders() to provide request-specific
-     * behavior.
-     *
-     * Retrieves all message headers.
-     *
-     * This method acts exactly like MessageInterface::getHeaders(), with one
-     * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host segment of the composed URI, if
-     * present.
-     *
-     * @see MessageInterface::getHeaders()
-     * @see UriInterface::getHost()
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
+     * {@inheritdoc}
      */
     public function getHeaders()
     {
@@ -55,22 +42,9 @@ class Request implements RequestInterface
     }
 
     /**
-     * Extends MessageInterface::getHeaderLines() to provide request-specific
-     * behavior.
-     *
-     * Retrieves a header by the given case-insensitive name as an array of strings.
-     *
-     * This method acts exactly like MessageInterface::getHeaderLines(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeaderLines()
-     * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * {@inheritdoc}
      */
-    public function getHeaderLines($header)
+    public function getHeader($header)
     {
         if (! $this->hasHeader($header)) {
             if (strtolower($header) === 'host'
@@ -87,5 +61,14 @@ class Request implements RequestInterface
         $value = $this->headers[$header];
         $value = is_array($value) ? $value : [$value];
         return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeaderLine($header)
+    {
+        $value = $this->getHeader($header);
+        return (implode(', ', $value));
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -17,7 +17,7 @@ class Request implements RequestInterface
     /**
      * @param null|string $uri URI for the request, if any.
      * @param null|string $method HTTP method for the request, if any.
-     * @param string|resource|StreamableInterface $body Message body, if any.
+     * @param string|resource|StreamInterface $body Message body, if any.
      * @param array $headers Headers for the message, if any.
      * @throws InvalidArgumentException for any invalid value.
      */

--- a/src/Request.php
+++ b/src/Request.php
@@ -62,13 +62,4 @@ class Request implements RequestInterface
         $value = is_array($value) ? $value : [$value];
         return $value;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeaderLine($header)
-    {
-        $value = $this->getHeader($header);
-        return (implode(', ', $value));
-    }
 }

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -168,14 +168,14 @@ trait RequestTrait
     }
 
     /**
-     * Create a new instance with the provided HTTP method.
+     * Return an instance with the provided HTTP method.
      *
      * While HTTP method names are typically all uppercase characters, HTTP
      * method names are case-sensitive and thus implementations SHOULD NOT
      * modify the given string.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * changed request method.
      *
      * @param string $method Case-insensitive method.
@@ -205,17 +205,31 @@ trait RequestTrait
     }
 
     /**
-     * Create a new instance with the provided URI.
+     * Returns an instance with the provided URI.
+     *
+     * This method will update the Host header of the returned request by
+     * default if the URI contains a host component. If the URI does not
+     * contain a host component, any pre-existing Host header will be carried
+     * over to the returned request.
+     *
+     * You can opt-in to preserving the original state of the Host header by
+     * setting `$preserveHost` to `true`. When `$preserveHost` is set to
+     * `true`, the returned request will not update the Host header of the
+     * returned message -- even if the message contains no Host header. This
+     * means that a call to `getHeader('Host')` on the original request MUST
+     * equal the return value of a call to `getHeader('Host')` on the returned
+     * request.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new UriInterface instance.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
+     * @param bool $preserveHost Preserve the original state of the Host header.
      * @return self
      */
-    public function withUri(UriInterface $uri)
+    public function withUri(UriInterface $uri, $preserveHost = false)
     {
         $new = clone $this;
         $new->uri = $uri;

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -237,6 +237,23 @@ trait RequestTrait
     {
         $new = clone $this;
         $new->uri = $uri;
+
+        if ($preserveHost) {
+            return $new;
+        }
+
+        if (! $uri->getHost()) {
+            return $new;
+        }
+
+        $host = $uri->getHost();
+        if ($uri->getPort()) {
+            $host .= ':' . $uri->getPort();
+        }
+
+        $new->headerNames['host'] = 'Host';
+        $new->headers['Host'] = array($host);
+
         return $new;
     }
 

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -123,6 +123,10 @@ trait RequestTrait
             $target .= '?' . $this->uri->getQuery();
         }
 
+        if (empty($target)) {
+            $target = '/';
+        }
+
         return $target;
     }
 

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -3,7 +3,7 @@ namespace Phly\Http;
 
 use InvalidArgumentException;
 use RuntimeException;
-use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -59,7 +59,7 @@ trait RequestTrait
      *
      * @param null|string $uri URI for the request, if any.
      * @param null|string $method HTTP method for the request, if any.
-     * @param string|resource|StreamableInterface $body Message body, if any.
+     * @param string|resource|StreamInterface $body Message body, if any.
      * @param array $headers Headers for the message, if any.
      * @throws InvalidArgumentException for any invalid value.
      */
@@ -73,11 +73,11 @@ trait RequestTrait
 
         $this->validateMethod($method);
 
-        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamableInterface) {
+        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
             throw new InvalidArgumentException(
                 'Body must be a string stream resource identifier, '
                 . 'an actual stream resource, '
-                . 'or a Psr\Http\Message\StreamableInterface implementation'
+                . 'or a Psr\Http\Message\StreamInterface implementation'
             );
         }
 
@@ -87,7 +87,7 @@ trait RequestTrait
 
         $this->method = $method;
         $this->uri    = $uri;
-        $this->stream = ($body instanceof StreamableInterface) ? $body : new Stream($body, 'r');
+        $this->stream = ($body instanceof StreamInterface) ? $body : new Stream($body, 'r');
 
         list($this->headerNames, $this->headers) = $this->filterHeaders($headers);
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -123,12 +123,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Gets the response Status-Code.
-     *
-     * The Status-Code is a 3-digit integer result code of the server's attempt
-     * to understand and satisfy the request.
-     *
-     * @return integer Status code.
+     * {@inheritdoc}
      */
     public function getStatusCode()
     {
@@ -136,17 +131,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Gets the response Reason-Phrase, a short textual description of the Status-Code.
-     *
-     * Because a Reason-Phrase is not a required element in a response
-     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * Status-Code.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string|null Reason phrase, or null if unknown.
+     * {@inheritdoc}
      */
     public function getReasonPhrase()
     {
@@ -160,25 +145,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Create a new instance with the specified status code, and optionally
-     * reason phrase, for the response.
-     *
-     * If no Reason-Phrase is specified, implementations MAY choose to default
-     * to the RFC 7231 or IANA recommended reason phrase for the response's
-     * Status-Code.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * updated status and reason phrase.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @param integer $code The 3-digit integer result code to set.
-     * @param null|string $reasonPhrase The reason phrase to use with the
-     *     provided status code; if none is provided, implementations MAY
-     *     use the defaults as suggested in the HTTP specification.
-     * @return self
-     * @throws InvalidArgumentException For invalid status code arguments.
+     * {@inheritdoc}
      */
     public function withStatus($code, $reasonPhrase = null)
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -3,7 +3,7 @@ namespace Phly\Http;
 
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * HTTP response encapsulation.
@@ -97,18 +97,18 @@ class Response implements ResponseInterface
     private $statusCode = 200;
 
     /**
-     * @param string|resource|StreamableInterface $stream Stream identifier and/or actual stream resource
+     * @param string|resource|StreamInterface $stream Stream identifier and/or actual stream resource
      * @param int $status Status code for the response, if any.
      * @param array $headers Headers for the response, if any.
      * @throws InvalidArgumentException on any invalid element.
      */
     public function __construct($body = 'php://memory', $status = 200, array $headers = [])
     {
-        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamableInterface) {
+        if (! is_string($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
             throw new InvalidArgumentException(
                 'Stream must be a string stream resource identifier, '
                 . 'an actual stream resource, '
-                . 'or a Psr\Http\Message\StreamableInterface implementation'
+                . 'or a Psr\Http\Message\StreamInterface implementation'
             );
         }
 
@@ -116,7 +116,7 @@ class Response implements ResponseInterface
             $this->validateStatus($status);
         }
 
-        $this->stream     = ($body instanceof StreamableInterface) ? $body : new Stream($body, 'wb+');
+        $this->stream     = ($body instanceof StreamInterface) ? $body : new Stream($body, 'wb+');
         $this->statusCode = $status ? (int) $status : 200;
 
         list($this->headerNames, $this->headers) = $this->filterHeaders($headers);

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -3,7 +3,7 @@ namespace Phly\Http;
 
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Server-side HTTP request
@@ -58,7 +58,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $fileParams Upload file information; should be in PHP's $_FILES format
      * @param null|string $uri URI for the request, if any.
      * @param null|string $method HTTP method for the request, if any.
-     * @param string|resource|StreamableInterface $body Message body, if any.
+     * @param string|resource|StreamInterface $body Message body, if any.
      * @param array $headers Headers for the message, if any.
      * @throws InvalidArgumentException for any invalid value.
      */
@@ -368,7 +368,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * Set the body stream
      *
-     * @param string|resource|StreamableInterface $stream
+     * @param string|resource|StreamInterface $stream
      * @return void
      */
     private function getStream($stream)
@@ -377,15 +377,15 @@ class ServerRequest implements ServerRequestInterface
             return new PhpInputStream();
         }
 
-        if (! is_string($stream) && ! is_resource($stream) && ! $stream instanceof StreamableInterface) {
+        if (! is_string($stream) && ! is_resource($stream) && ! $stream instanceof StreamInterface) {
             throw new InvalidArgumentException(
                 'Stream must be a string stream resource identifier, '
                 . 'an actual stream resource, '
-                . 'or a Psr\Http\Message\StreamableInterface implementation'
+                . 'or a Psr\Http\Message\StreamInterface implementation'
             );
         }
 
-        if (! $stream instanceof StreamableInterface) {
+        if (! $stream instanceof StreamInterface) {
             return new Stream($stream, 'r');
         }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -77,13 +77,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve server parameters.
-     *
-     * Retrieves data related to the incoming request environment,
-     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
-     * REQUIRED to originate from $_SERVER.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getServerParams()
     {
@@ -91,16 +85,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve the upload file metadata.
-     *
-     * This method MUST return file upload metadata in the same structure
-     * as PHP's $_FILES superglobal.
-     *
-     * These values MUST remain immutable over the course of the incoming
-     * request. They SHOULD be injected during instantiation, such as from PHP's
-     * $_FILES superglobal, but MAY be derived from other sources.
-     *
-     * @return array Upload file(s) metadata, if any.
+     * {@inheritdoc}
      */
     public function getFileParams()
     {
@@ -108,14 +93,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve cookies.
-     *
-     * Retrieves cookies sent by the client to the server.
-     *
-     * The data MUST be compatible with the structure of the $_COOKIE
-     * superglobal.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getCookieParams()
     {
@@ -123,18 +101,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Create a new instance with the specified cookies.
-     *
-     * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
-     * be compatible with the structure of $_COOKIE. Typically, this data will
-     * be injected at instantiation.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * updated cookie values.
-     *
-     * @param array $cookies Array of key/value pairs representing cookies.
-     * @return self
+     * {@inheritdoc}
      */
     public function withCookieParams(array $cookies)
     {
@@ -144,16 +111,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve query string arguments.
-     *
-     * Retrieves the deserialized query string arguments, if any.
-     *
-     * Note: the query params might not be in sync with the URL or server
-     * params. If you need to ensure you are only getting the original
-     * values, you may need to parse the composed URL or the `QUERY_STRING`
-     * composed in the server params.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getQueryParams()
     {
@@ -161,26 +119,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Create a new instance with the specified query string arguments.
-     *
-     * These values SHOULD remain immutable over the course of the incoming
-     * request. They MAY be injected during instantiation, such as from PHP's
-     * $_GET superglobal, or MAY be derived from some other value such as the
-     * URI. In cases where the arguments are parsed from the URI, the data
-     * MUST be compatible with what PHP's parse_str() would return for
-     * purposes of how duplicate query parameters are handled, and how nested
-     * sets are handled.
-     *
-     * Setting query string arguments MUST NOT change the URL stored by the
-     * request, nor the values in the server params.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * updated query string arguments.
-     *
-     * @param array $query Array of query string arguments, typically from
-     *     $_GET.
-     * @return self
+     * {@inheritdoc}
      */
     public function withQueryParams(array $query)
     {
@@ -190,18 +129,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve any parameters provided in the request body.
-     *
-     * If the request Content-Type is application/x-www-form-urlencoded and the
-     * request method is POST, this method MUST return the contents of $_POST.
-     *
-     * Otherwise, this method may return any results of deserializing
-     * the request body content; as parsing returns structured content, the
-     * potential types MUST be arrays or objects only. A null value indicates
-     * the absence of body content.
-     *
-     * @return null|array|object The deserialized body parameters, if any.
-     *     These will typically be an array or object.
+     * {@inheritdoc}
      */
     public function getParsedBody()
     {
@@ -209,30 +137,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Create a new instance with the specified body parameters.
-     *
-     * These MAY be injected during instantiation.
-     *
-     * If the request Content-Type is application/x-www-form-urlencoded and the
-     * request method is POST, use this method ONLY to inject the contents of
-     * $_POST.
-     *
-     * The data IS NOT REQUIRED to come from $_POST, but MUST be the results of
-     * deserializing the request body content. Deserialization/parsing returns
-     * structured data, and, as such, this method ONLY accepts arrays or objects,
-     * or a null value if nothing was available to parse.
-     *
-     * As an example, if content negotiation determines that the request data
-     * is a JSON payload, this method could be used to create a request
-     * instance with the deserialized parameters.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * updated body parameters.
-     *
-     * @param null|array|object $data The deserialized body data. This will
-     *     typically be in an array or object.
-     * @return self
+     * {@inheritdoc}
      */
     public function withParsedBody($data)
     {
@@ -242,15 +147,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve attributes derived from the request.
-     *
-     * The request "attributes" may be used to allow injection of any
-     * parameters derived from the request: e.g., the results of path
-     * match operations; the results of decrypting cookies; the results of
-     * deserializing non-form-encoded message bodies; etc. Attributes
-     * will be application and request specific, and CAN be mutable.
-     *
-     * @return array Attributes derived from the request.
+     * {@inheritdoc}
      */
     public function getAttributes()
     {
@@ -258,19 +155,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Retrieve a single derived request attribute.
-     *
-     * Retrieves a single derived request attribute as described in
-     * getAttributes(). If the attribute has not been previously set, returns
-     * the default value as provided.
-     *
-     * This method obviates the need for a hasAttribute() method, as it allows
-     * specifying a default value to return if the attribute is not found.
-     *
-     * @see getAttributes()
-     * @param string $attribute Attribute name.
-     * @param mixed $default Default value to return if the attribute does not exist.
-     * @return mixed
+     * {@inheritdoc}
      */
     public function getAttribute($attribute, $default = null)
     {
@@ -282,19 +167,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Create a new instance with the specified derived request attribute.
-     *
-     * This method allows setting a single derived request attribute as
-     * described in getAttributes().
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * updated attribute.
-     *
-     * @see getAttributes()
-     * @param string $attribute The attribute name.
-     * @param mixed $value The value of the attribute.
-     * @return self
+     * {@inheritdoc}
      */
     public function withAttribute($attribute, $value)
     {
@@ -304,19 +177,7 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Create a new instance that removes the specified derived request
-     * attribute.
-     *
-     * This method allows removing a single derived request attribute as
-     * described in getAttributes().
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that removes
-     * the attribute.
-     *
-     * @see getAttributes()
-     * @param string $attribute The attribute name.
-     * @return self
+     * {@inheritdoc}
      */
     public function withoutAttribute($attribute)
     {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -32,7 +32,13 @@ class Stream implements StreamInterface
         if (is_resource($stream)) {
             $this->resource = $stream;
         } elseif (is_string($stream)) {
+            set_error_handler(function ($errno, $errstr) {
+                throw new InvalidArgumentException(
+                    'Invalid file provided for stream; must be a valid path with valid permissions'
+                );
+            }, E_WARNING);
             $this->resource = fopen($stream, $mode);
+            restore_error_handler();
         } else {
             throw new InvalidArgumentException(
                 'Invalid stream provided; must be a string stream identifier or resource'

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,12 +2,12 @@
 namespace Phly\Http;
 
 use InvalidArgumentException;
-use Psr\Http\Message\StreamableInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Implementation of PSR HTTP streams
  */
-class Stream implements StreamableInterface
+class Stream implements StreamInterface
 {
     /**
      * @var resource
@@ -89,8 +89,8 @@ class Stream implements StreamableInterface
 
     /**
      * Attach a new resource to the instance
-     * 
-     * @param resource|string $resource Resource to attach, or a string 
+     *
+     * @param resource|string $resource Resource to attach, or a string
      *                                  representing the resource to attach.
      * @param string $mode If a non-resource is provided, the mode to use
      *                     when creating the resource.
@@ -205,7 +205,7 @@ class Stream implements StreamableInterface
 
     /**
      * Rewind the stream
-     * 
+     *
      * @return bool Returns TRUE on success, FALSE on failure
      */
     public function rewind()
@@ -307,7 +307,7 @@ class Stream implements StreamableInterface
 
     /**
      * Retrieve metadata from the underlying stream.
-     * 
+     *
      * @see http://php.net/stream_get_meta_data for a description of the expected output.
      * @return array
      */

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -40,14 +40,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Reads all data from the stream into a string, from the beginning to end.
-     *
-     * This method MUST attempt to seek to the beginning of the stream before
-     * reading data and read the stream until the end is reached.
-     *
-     * Warning: This could attempt to load a large amount of data into memory.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -59,9 +52,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Closes the stream and any underlying resources.
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function close()
     {
@@ -74,11 +65,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Separates any underlying resources from the stream.
-     *
-     * After the stream has been detached, the stream is in an unusable state.
-     *
-     * @return resource|null
+     * {@inheritdoc}
      */
     public function detach()
     {
@@ -88,14 +75,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Attach a new resource to the instance
-     *
-     * @param resource|string $resource Resource to attach, or a string
-     *                                  representing the resource to attach.
-     * @param string $mode If a non-resource is provided, the mode to use
-     *                     when creating the resource.
-     * @throws InvalidArgumentException If a non-resource or non-string is provided,
-     *                                  raises an exception.
+     * {@inheritdoc}
      */
     public function attach($resource, $mode = 'r')
     {
@@ -122,9 +102,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Get the size of the stream if known
-     *
-     * @return int|null Returns the size in bytes if known, or null if unknown
+     * {@inheritdoc}
      */
     public function getSize()
     {
@@ -137,9 +115,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns the current position of the file read/write pointer
-     *
-     * @return int|bool Position of the file pointer or false on error
+     * {@inheritdoc}
      */
     public function tell()
     {
@@ -151,9 +127,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns true if the stream is at the end of the stream.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function eof()
     {
@@ -165,9 +139,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns whether or not the stream is seekable
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isSeekable()
     {
@@ -180,18 +152,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Seek to a position in the stream
-     *
-     * @param int $offset Stream offset
-     * @param int $whence Specifies how the cursor position will be calculated
-     *                    based on the seek offset. Valid values are identical
-     *                    to the built-in PHP $whence values for `fseek()`.
-     *                    SEEK_SET: Set position equal to offset bytes
-     *                    SEEK_CUR: Set position to current location plus offset
-     *                    SEEK_END: Set position to end-of-stream plus offset
-     *
-     * @return bool Returns TRUE on success or FALSE on failure
-     * @link   http://www.php.net/manual/en/function.fseek.php
+     * {@inheritdoc}
      */
     public function seek($offset, $whence = SEEK_SET)
     {
@@ -204,9 +165,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Rewind the stream
-     *
-     * @return bool Returns TRUE on success, FALSE on failure
+     * {@inheritdoc}
      */
     public function rewind()
     {
@@ -219,9 +178,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns whether or not the stream is writable
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isWritable()
     {
@@ -234,12 +191,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Write data to the stream.
-     *
-     * @param string $string The string that is to be written.
-     *
-     * @return int|bool Returns the number of bytes written to the stream on
-     *                  success or FALSE on failure.
+     * {@inheritdoc}
      */
     public function write($string)
     {
@@ -251,9 +203,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns whether or not the stream is readable
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isReadable()
     {
@@ -268,15 +218,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Read data from the stream
-     *
-     * @param int $length Read up to $length bytes from the object and return
-     *                    them. Fewer than $length bytes may be returned if
-     *                    underlying stream call returns fewer bytes.
-     *
-     * @return string|false Returns the data read from the stream; in the event
-     *                      of an error or inability to read, can return boolean
-     *                      false.
+     * {@inheritdoc}
      */
     public function read($length)
     {
@@ -292,9 +234,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Returns the remaining contents in a string, up to maxlength bytes.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getContents()
     {
@@ -306,10 +246,7 @@ class Stream implements StreamInterface
     }
 
     /**
-     * Retrieve metadata from the underlying stream.
-     *
-     * @see http://php.net/stream_get_meta_data for a description of the expected output.
-     * @return array
+     * {@inheritdoc}
      */
     public function getMetadata($key = null)
     {

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -1,0 +1,213 @@
+<?php
+namespace Phly\Http;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+class UploadedFile implements UploadedFileInterface
+{
+    /**
+     * @var string
+     */
+    private $clientFilename;
+
+    /**
+     * @var string
+     */
+    private $clientMediaType;
+
+    /**
+     * @var int
+     */
+    private $error;
+
+    /**
+     * @var null|string
+     */
+    private $file;
+
+    /**
+     * @var bool
+     */
+    private $moved = false;
+
+    /**
+     * @var int
+     */
+    private $size;
+
+    /**
+     * @var null|StreamInterface
+     */
+    private $stream;
+
+    public function __construct($streamOrFile, $size, $errorStatus, $clientFilename = null, $clientMediaType = null)
+    {
+        if (is_string($streamOrFile)) {
+            $this->file = $streamOrFile;
+        }
+        if (is_resource($streamOrFile)) {
+            $this->stream = new Stream($streamOrFile);
+        }
+
+        if (! $this->file && ! $this->stream) {
+            if (! $streamOrFile instanceof StreamInterface) {
+                throw new InvalidArgumentException('Invalid stream or file provided for UploadedFile');
+            }
+            $this->stream = $streamOrFile;
+        }
+
+        if (! is_int($size)) {
+            throw new InvalidArgumentException('Invalid size provided for UploadedFile; must be an int');
+        }
+        $this->size = $size;
+
+        if (! is_int($errorStatus)
+            || 0 > $errorStatus
+            || 8 < $errorStatus
+        ) {
+            throw new InvalidArgumentException(
+                'Invalid error status for UploadedFile; must be an UPLOAD_ERR_* constant'
+            );
+        }
+        $this->error = $errorStatus;
+
+        if (null !== $clientFilename && ! is_string($clientFilename)) {
+            throw new InvalidArgumentException(
+                'Invalid client filename provided for UploadedFile; must be null or a string'
+            );
+        }
+        $this->clientFilename = $clientFilename;
+
+        if (null !== $clientMediaType && ! is_string($clientMediaType)) {
+            throw new InvalidArgumentException(
+                'Invalid client media type provided for UploadedFile; must be null or a string'
+            );
+        }
+        $this->clientMediaType = $clientMediaType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStream()
+    {
+        if ($this->moved) {
+            throw new RuntimeException('Cannot retrieve stream after it has already been moved');
+        }
+
+        if ($this->stream instanceof StreamInterface) {
+            return $this->stream;
+        }
+
+        $this->stream = new Stream($this->file);
+        return $this->stream;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see http://php.net/is_uploaded_file
+     * @see http://php.net/move_uploaded_file
+     * @param string $path Path to which to move the uploaded file.
+     * @throws \InvalidArgumentException if the $path specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
+     *     the second or subsequent call to the method.
+     */
+    public function move($path)
+    {
+        if (! is_string($path)) {
+            throw new InvalidArgumentException(
+                'Invalid path provided for move operation; must be a string'
+            );
+        }
+
+        if (empty($path)) {
+            throw new InvalidArgumentException(
+                'Invalid path provided for move operation; must be a non-empty string'
+            );
+        }
+
+        if ($this->moved) {
+            throw new RuntimeException('Cannot move file; already moved!');
+        }
+
+        $sapi = PHP_SAPI;
+        switch (true) {
+            case (empty($sapi) || 0 === strpos($sapi, 'cli') || ! $this->file):
+                // Non-SAPI environment, or no filename present
+                $this->writeFile($path);
+                break;
+            default:
+                // SAPI environment, with file present
+                if (false === move_uploaded_file($this->file, $path)) {
+                    throw new RuntimeException('Error occurred while moving uploaded file');
+                }
+                break;
+        }
+
+        $this->moved = true;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see http://php.net/manual/en/features.file-upload.errors.php
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename()
+    {
+        return $this->clientFilename;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientMediaType()
+    {
+        return $this->clientMediaType;
+    }
+
+    /**
+     * Write internal stream to given path
+     * 
+     * @param string $path 
+     */
+    private function writeFile($path)
+    {
+        $handle = fopen($path, 'wb+');
+        if (false === $handle) {
+            throw new RuntimeException('Unable to write to designated path');
+        }
+
+        $this->stream->rewind();
+        while (! $this->stream->eof()) {
+            fwrite($handle, $this->stream->read(4096));
+        }
+
+        fclose($handle);
+    }
+}

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -109,19 +109,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Return the string representation of the URI.
-     *
-     * Concatenates the various segments of the URI, using the appropriate
-     * delimiters:
-     *
-     * - If a scheme is present, "://" MUST append the value.
-     * - If the authority information is present, that value will be
-     *   contatenated.
-     * - If a path is present, it MUST be prefixed by a "/" character.
-     * - If a query string is present, it MUST be prefixed by a "?" character.
-     * - If a URI fragment is present, it MUST be prefixed by a "#" character.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -141,16 +129,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the URI scheme.
-     *
-     * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accommodate other schemes if required.
-     *
-     * If no scheme is present, this method MUST return an empty string.
-     *
-     * The string returned MUST omit the trailing "://" delimiter if present.
-     *
-     * @return string The scheme of the URI.
+     * {@inheritdoc}
      */
     public function getScheme()
     {
@@ -158,22 +137,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the authority portion of the URI.
-     *
-     * The authority portion of the URI is:
-     *
-     * <pre>
-     * [user-info@]host[:port]
-     * </pre>
-     *
-     * If the port component is not set or is the standard port for the current
-     * scheme, it SHOULD NOT be included.
-     *
-     * This method MUST return an empty string if no authority information is
-     * present.
-     *
-     * @return string Authority portion of the URI, in "[user-info@]host[:port]"
-     *     format.
+     * {@inheritdoc}
      */
     public function getAuthority()
     {
@@ -194,16 +158,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the user information portion of the URI, if present.
-     *
-     * If a user is present in the URI, this will return that value;
-     * additionally, if the password is also present, it will be appended to the
-     * user value, with a colon (":") separating the values.
-     *
-     * Implementations MUST NOT return the "@" suffix when returning this value.
-     *
-     * @return string User information portion of the URI, if present, in
-     *     "username[:password]" format.
+     * {@inheritdoc}
      */
     public function getUserInfo()
     {
@@ -211,12 +166,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the host segment of the URI.
-     *
-     * This method MUST return a string; if no host segment is present, an
-     * empty string MUST be returned.
-     *
-     * @return string Host segment of the URI.
+     * {@inheritdoc}
      */
     public function getHost()
     {
@@ -224,19 +174,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the port segment of the URI.
-     *
-     * If a port is present, and it is non-standard for the current scheme,
-     * this method MUST return it as an integer. If the port is the standard port
-     * used with the current scheme, this method SHOULD return null.
-     *
-     * If no port is present, and no scheme is present, this method MUST return
-     * a null value.
-     *
-     * If no port is present, but a scheme is present, this method MAY return
-     * the standard port for that scheme, but SHOULD return null.
-     *
-     * @return null|int The port for the URI.
+     * {@inheritdoc}
      */
     public function getPort()
     {
@@ -246,14 +184,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the path segment of the URI.
-     *
-     * This method MUST return a string; if no path is present it MUST return
-     * an empty string.
-     *
-     * If the path is empty, this method MUST return "/".
-     *
-     * @return string The path segment of the URI.
+     * {@inheritdoc}
      */
     public function getPath()
     {
@@ -265,14 +196,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the query string of the URI.
-     *
-     * This method MUST return a string; if no query string is present, it MUST
-     * return an empty string.
-     *
-     * The string returned MUST omit the leading "?" character.
-     *
-     * @return string The URI query string.
+     * {@inheritdoc}
      */
     public function getQuery()
     {
@@ -280,14 +204,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Retrieve the fragment segment of the URI.
-     *
-     * This method MUST return a string; if no fragment is present, it MUST
-     * return an empty string.
-     *
-     * The string returned MUST omit the leading "#" character.
-     *
-     * @return string The URI fragment.
+     * {@inheritdoc}
      */
     public function getFragment()
     {
@@ -295,20 +212,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified scheme.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified scheme. If the scheme
-     * provided includes the "://" delimiter, it MUST be removed.
-     *
-     * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accommodate other schemes if required.
-     *
-     * An empty scheme is equivalent to removing the scheme.
-     *
-     * @param string $scheme The scheme to use with the new instance.
-     * @return self A new instance with the specified scheme.
-     * @throws InvalidArgumentException for invalid or unsupported schemes.
+     * {@inheritdoc}
      */
     public function withScheme($scheme)
     {
@@ -326,18 +230,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified user information.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified user information.
-     *
-     * Password is optional, but the user information MUST include the
-     * user; an empty string for the user is equivalent to removing user
-     * information.
-     *
-     * @param string $user User name to use for authority.
-     * @param null|string $password Password associated with $user.
-     * @return self A new instance with the specified user information.
+     * {@inheritdoc}
      */
     public function withUserInfo($user, $password = null)
     {
@@ -358,16 +251,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified host.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified host.
-     *
-     * An empty host value is equivalent to removing the host.
-     *
-     * @param string $host Hostname to use with the new instance.
-     * @return self A new instance with the specified host.
-     * @throws InvalidArgumentException for invalid hostnames.
+     * {@inheritdoc}
      */
     public function withHost($host)
     {
@@ -383,21 +267,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified port.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified port.
-     *
-     * Implementations MUST raise an exception for ports outside the
-     * established TCP and UDP port ranges.
-     *
-     * A null value provided for the port is equivalent to removing the port
-     * information.
-     *
-     * @param null|int $port Port to use with the new instance; a null value
-     *     removes the port information.
-     * @return self A new instance with the specified port.
-     * @throws InvalidArgumentException for invalid ports.
+     * {@inheritdoc}
      */
     public function withPort($port)
     {
@@ -429,19 +299,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified path.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified path.
-     *
-     * The path MUST be prefixed with "/"; if not, the implementation MAY
-     * provide the prefix itself.
-     *
-     * An empty path value is equivalent to removing the path.
-     *
-     * @param string $path The path to use with the new instance.
-     * @return self A new instance with the specified path.
-     * @throws InvalidArgumentException for invalid paths.
+     * {@inheritdoc}
      */
     public function withPath($path)
     {
@@ -477,20 +335,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified query string.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified query string.
-     *
-     * If the query string is prefixed by "?", that character MUST be removed.
-     * Additionally, the query string SHOULD be parseable by parse_str() in
-     * order to be valid.
-     *
-     * An empty query string value is equivalent to removing the query string.
-     *
-     * @param string $query The query string to use with the new instance.
-     * @return self A new instance with the specified query string.
-     * @throws InvalidArgumentException for invalid query strings.
+     * {@inheritdoc}
      */
     public function withQuery($query)
     {
@@ -520,17 +365,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * Create a new instance with the specified URI fragment.
-     *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified URI fragment.
-     *
-     * If the fragment is prefixed by "#", that character MUST be removed.
-     *
-     * An empty fragment value is equivalent to removing the fragment.
-     *
-     * @param string $fragment The URI fragment to use with the new instance.
-     * @return self A new instance with the specified URI fragment.
+     * {@inheritdoc}
      */
     public function withFragment($fragment)
     {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -188,10 +188,6 @@ class Uri implements UriInterface
      */
     public function getPath()
     {
-        if (empty($this->path)) {
-            return '/';
-        }
-
         return $this->path;
     }
 
@@ -425,6 +421,10 @@ class Uri implements UriInterface
         }
 
         if ($path) {
+            if (empty($path) || '/' !== substr($path, 0, 1)) {
+                $path = '/' . $path;
+            }
+
             $uri .= $path;
         }
 
@@ -495,13 +495,6 @@ class Uri implements UriInterface
      */
     private function filterPath($path)
     {
-        if ($path !== null
-            && (empty($path)
-            || substr($path, 0, 1) !== '/')
-        ) {
-            $path = '/' . $path;
-        }
-
         return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'urlEncodeChar'],

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -38,18 +38,18 @@ class MessageTraitTest extends TestCase
         $this->assertSame($stream, $message->getBody());
     }
 
-    public function testGetHeaderLinesReturnsHeaderValueAsArray()
+    public function testGetHeaderReturnsHeaderValueAsArray()
     {
         $message = $this->message->withHeader('X-Foo', ['Foo', 'Bar']);
         $this->assertNotSame($this->message, $message);
-        $this->assertEquals(['Foo', 'Bar'], $message->getHeaderLines('X-Foo'));
+        $this->assertEquals(['Foo', 'Bar'], $message->getHeader('X-Foo'));
     }
 
-    public function testGetHeaderReturnsHeaderValueAsCommaConcatenatedString()
+    public function testGetHeaderLineReturnsHeaderValueAsCommaConcatenatedString()
     {
         $message = $this->message->withHeader('X-Foo', ['Foo', 'Bar']);
         $this->assertNotSame($this->message, $message);
-        $this->assertEquals('Foo,Bar', $message->getHeader('X-Foo'));
+        $this->assertEquals('Foo,Bar', $message->getHeaderLine('X-Foo'));
     }
 
     public function testGetHeadersKeepsHeaderCaseSensitivity()
@@ -86,7 +86,7 @@ class MessageTraitTest extends TestCase
         $this->assertNotSame($this->message, $message);
         $message2 = $message->withAddedHeader('X-Foo', 'Bar');
         $this->assertNotSame($message, $message2);
-        $this->assertEquals('Foo,Bar', $message2->getHeader('X-Foo'));
+        $this->assertEquals('Foo,Bar', $message2->getHeaderLine('X-Foo'));
     }
 
     public function testCanRemoveHeaders()
@@ -134,7 +134,7 @@ class MessageTraitTest extends TestCase
     /**
      * @dataProvider invalidGeneralHeaderValues
      */
-    public function testSetHeaderRaisesExceptionForInvalidNestedHeaderValue($value)
+    public function testWithHeaderRaisesExceptionForInvalidNestedHeaderValue($value)
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid header value');
         $message = $this->message->withHeader('X-Foo', [ $value ]);
@@ -155,7 +155,7 @@ class MessageTraitTest extends TestCase
     /**
      * @dataProvider invalidHeaderValues
      */
-    public function testSetHeaderRaisesExceptionForInvalidValueType($value)
+    public function testWithHeaderRaisesExceptionForInvalidValueType($value)
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid header value');
         $message = $this->message->withHeader('X-Foo', $value);
@@ -164,13 +164,13 @@ class MessageTraitTest extends TestCase
     /**
      * @dataProvider invalidGeneralHeaderValues
      */
-    public function testAddHeaderRaisesExceptionForNonStringNonArrayValue($value)
+    public function testWithAddedHeaderRaisesExceptionForNonStringNonArrayValue($value)
     {
         $this->setExpectedException('InvalidArgumentException', 'must be a string');
         $message = $this->message->withAddedHeader('X-Foo', $value);
     }
 
-    public function testRemoveHeaderDoesNothingIfHeaderDoesNotExist()
+    public function testWithoutHeaderDoesNothingIfHeaderDoesNotExist()
     {
         $this->assertFalse($this->message->hasHeader('X-Foo'));
         $message = $this->message->withoutHeader('X-Foo');
@@ -183,5 +183,15 @@ class MessageTraitTest extends TestCase
         $headers = ['X-Foo' => ['bar']];
         $this->message = new Request(null, null, $this->stream, $headers);
         $this->assertSame($headers, $this->message->getHeaders());
+    }
+
+    public function testGetHeaderReturnsAnEmptyArrayWhenHeaderDoesNotExist()
+    {
+        $this->assertSame([], $this->message->getHeader('X-Foo-Bar'));
+    }
+
+    public function testGetHeaderLineReturnsNullWhenHeaderDoesNotExist()
+    {
+        $this->assertNull($this->message->getHeaderLine('X-Foo-Bar'));
     }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -347,4 +347,39 @@ class RequestTest extends TestCase
         $request = new Request(new Uri());
         $this->assertNull($request->getHeaderLine('host'));
     }
+
+    public function testPassingPreserveHostFlagWhenUpdatingUriDoesNotUpdateHostHeader()
+    {
+        $request = (new Request())
+            ->withAddedHeader('Host', 'example.com');
+
+        $uri = (new Uri())->withHost('www.example.com');
+        $new = $request->withUri($uri, true);
+
+        $this->assertEquals('example.com', $new->getHeaderLine('Host'));
+    }
+
+    public function testNotPassingPreserveHostFlagWhenUpdatingUriWithoutHostDoesNotUpdateHostHeader()
+    {
+        $request = (new Request())
+            ->withAddedHeader('Host', 'example.com');
+
+        $uri = new Uri();
+        $new = $request->withUri($uri);
+
+        $this->assertEquals('example.com', $new->getHeaderLine('Host'));
+    }
+
+    public function testHostHeaderUpdatesToUriHostAndPortWhenPreserveHostDisabledAndNonStandardPort()
+    {
+        $request = (new Request())
+            ->withAddedHeader('Host', 'example.com');
+
+        $uri = (new Uri())
+            ->withHost('www.example.com')
+            ->withPort(10081);
+        $new = $request->withUri($uri);
+
+        $this->assertEquals('www.example.com:10081', $new->getHeaderLine('Host'));
+    }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -299,54 +299,52 @@ class RequestTest extends TestCase
     {
         $request = new Request('http://example.com');
         $header = $request->getHeader('host');
-        $this->assertEquals('example.com', $header);
+        $this->assertEquals(array('example.com'), $header);
     }
 
     /**
      * @group 39
      */
-    public function testGetHostHeaderReturnsNullIfNoUriPresent()
+    public function testGetHostHeaderReturnsEmptyArrayIfNoUriPresent()
     {
         $request = new Request();
-        $this->assertNull($request->getHeader('host'));
+        $this->assertSame([], $request->getHeader('host'));
     }
 
     /**
      * @group 39
      */
-    public function testGetHostHeaderReturnsNullIfUriDoesNotContainHost()
+    public function testGetHostHeaderReturnsEmptyArrayIfUriDoesNotContainHost()
     {
         $request = new Request(new Uri());
-        $this->assertNull($request->getHeader('host'));
+        $this->assertSame([], $request->getHeader('host'));
     }
 
     /**
      * @group 39
      */
-    public function testGetHostHeaderLinesReturnsUriHostWhenPresent()
+    public function testGetHostHeaderLineReturnsUriHostWhenPresent()
     {
         $request = new Request('http://example.com');
-        $header = $request->getHeaderLines('host');
+        $header = $request->getHeaderLine('host');
         $this->assertContains('example.com', $header);
     }
 
     /**
      * @group 39
      */
-    public function testGetHostHeaderLinesReturnsEmptyArrayIfNoUriPresent()
+    public function testGetHostHeaderLineReturnsNullIfNoUriPresent()
     {
         $request = new Request();
-        $header = $request->getHeaderLines('host');
-        $this->assertSame([], $header);
+        $this->assertNull($request->getHeaderLine('host'));
     }
 
     /**
      * @group 39
      */
-    public function testGetHostHeaderLinesReturnsEmptyArrayIfUriDoesNotContainHost()
+    public function testGetHostHeaderLineReturnsNullIfUriDoesNotContainHost()
     {
         $request = new Request(new Uri());
-        $header = $request->getHeaderLines('host');
-        $this->assertSame([], $header);
+        $this->assertNull($request->getHeaderLine('host'));
     }
 }

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -3,6 +3,7 @@ namespace PhlyTest\Http;
 
 use Phly\Http\ServerRequest;
 use Phly\Http\ServerRequestFactory;
+use Phly\Http\UploadedFile;
 use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
@@ -345,14 +346,23 @@ class ServerRequestFactoryTest extends TestCase
         $cookies['cookies'] = true;
         $query['query']     = true;
         $body['body']       = true;
-        $files['files']     = true;
+        $files              = [ 'files' => [
+            'tmp_name' => 'php://temp',
+            'size'     => 0,
+            'error'    => 0,
+            'name'     => 'foo.bar',
+            'type'     => 'text/plain',
+        ]];
+        $expectedFiles = [
+            'files' => new UploadedFile('php://temp', 0, 0, 'foo.bar', 'text/plain')
+        ];
 
         $request = ServerRequestFactory::fromGlobals($server, $query, $body, $cookies, $files);
         $this->assertInstanceOf('Phly\Http\ServerRequest', $request);
         $this->assertEquals($cookies, $request->getCookieParams());
         $this->assertEquals($query, $request->getQueryParams());
         $this->assertEquals($body, $request->getParsedBody());
-        $this->assertEquals($files, $request->getFileParams());
+        $this->assertEquals($expectedFiles, $request->getUploadedFiles());
         $this->assertEmpty($request->getAttributes());
     }
 

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -171,7 +171,7 @@ class ServerRequestFactoryTest extends TestCase
     public function testMarshalHostAndPortReturnsEmptyValuesIfNoHostHeaderAndNoServerName()
     {
         $request = new ServerRequest();
-        $request = $request->withUri(new Uri('http://example.com/'));
+        $request = $request->withUri(new Uri());
 
         $accumulator = (object) ['host' => '', 'port' => null];
         ServerRequestFactory::marshalHostAndPort($accumulator, [], $request);
@@ -196,7 +196,7 @@ class ServerRequestFactoryTest extends TestCase
     public function testMarshalHostAndPortReturnsServerPortForPortWhenPresentWithServerName()
     {
         $request = new ServerRequest();
-        $request = $request->withUri(new Uri('http://example.com/'));
+        $request = $request->withUri(new Uri());
 
         $server  = [
             'SERVER_NAME' => 'example.com',
@@ -225,7 +225,7 @@ class ServerRequestFactoryTest extends TestCase
     public function testMarshalHostAndPortReturnsServerAddrForHostIfPresentAndHostIsIpv6Address()
     {
         $request = new ServerRequest();
-        $request = $request->withUri(new Uri('http://example.com/'));
+        $request = $request->withUri(new Uri());
 
         $server  = [
             'SERVER_ADDR' => 'FE80::0202:B3FF:FE1E:8329',
@@ -241,7 +241,7 @@ class ServerRequestFactoryTest extends TestCase
     public function testMarshalHostAndPortWillDetectPortInIpv6StyleHost()
     {
         $request = new ServerRequest();
-        $request = $request->withUri(new Uri('http://example.com/'));
+        $request = $request->withUri(new Uri());
 
         $server  = [
             'SERVER_ADDR' => 'FE80::0202:B3FF:FE1E:8329',

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -2,6 +2,7 @@
 namespace PhlyTest\Http;
 
 use Phly\Http\ServerRequest;
+use Phly\Http\UploadedFile;
 use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
@@ -44,9 +45,9 @@ class ServerRequestTest extends TestCase
         $this->assertEquals($value, $request->getCookieParams());
     }
 
-    public function testFileParamsAreEmptyByDefault()
+    public function testUploadedFilesAreEmptyByDefault()
     {
-        $this->assertEmpty($this->request->getFileParams());
+        $this->assertEmpty($this->request->getUploadedFiles());
     }
 
     public function testParsedBodyIsEmptyByDefault()
@@ -90,13 +91,16 @@ class ServerRequestTest extends TestCase
 
     public function testUsesProvidedConstructorArguments()
     {
-        $server = $files = [
+        $server = [
             'foo' => 'bar',
             'baz' => 'bat',
         ];
 
         $server['server'] = true;
-        $files['files']   = true;
+
+        $files = [
+            'files' => new UploadedFile('php://temp', 0, 0),
+        ];
 
         $uri = new Uri('http://example.com');
         $method = 'POST';
@@ -114,7 +118,7 @@ class ServerRequestTest extends TestCase
         );
 
         $this->assertEquals($server, $request->getServerParams());
-        $this->assertEquals($files, $request->getFileParams());
+        $this->assertEquals($files, $request->getUploadedFiles());
 
         $this->assertSame($uri, $request->getUri());
         $this->assertEquals($method, $request->getMethod());

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -128,7 +128,7 @@ class StreamTest extends TestCase
         $this->assertEquals(2, $stream->tell());
     }
 
-    public function testTellReturnsFalseIfResourceIsDetached()
+    public function testTellRaisesExceptionIfResourceIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'phly');
         file_put_contents($this->tmpnam, 'FOO BAR');
@@ -137,7 +137,8 @@ class StreamTest extends TestCase
 
         fseek($resource, 2);
         $stream->detach();
-        $this->assertFalse($stream->tell());
+        $this->setExpectedException('RuntimeException', 'No resource');
+        $stream->tell();
     }
 
     public function testEofReportsFalseWhenNotAtEndOfStream()
@@ -185,7 +186,7 @@ class StreamTest extends TestCase
         $this->assertTrue($stream->isSeekable());
     }
 
-    public function testIsSeekableReturnsFalseForNonSeekableStreams()
+    public function testIsSeekableRaisesExceptionForNonSeekableStreams()
     {
         $this->markTestIncomplete('Do not know how to create a non-seekable stream');
     }
@@ -221,15 +222,15 @@ class StreamTest extends TestCase
         $this->assertEquals(0, $stream->tell());
     }
 
-    public function testSeekReturnsFalseWhenStreamIsDetached()
+    public function testSeekRaisesExceptionWhenStreamIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'phly');
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'wb+');
         $stream = new Stream($resource);
         $stream->detach();
-        $this->assertFalse($stream->seek(2));
-        $this->assertEquals(0, ftell($resource));
+        $this->setExpectedException('RuntimeException', 'No resource');
+        $stream->seek(2);
     }
 
     public function testIsWritableReturnsFalseWhenStreamIsDetached()
@@ -242,14 +243,15 @@ class StreamTest extends TestCase
         $this->assertFalse($stream->isWritable());
     }
 
-    public function testWriteReturnsFalseWhenStreamIsDetached()
+    public function testWriteRaisesExceptionWhenStreamIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'phly');
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'wb+');
         $stream = new Stream($resource);
         $stream->detach();
-        $this->assertFalse($stream->write('bar'));
+        $this->setExpectedException('RuntimeException', 'No resource');
+        $stream->write('bar');
     }
 
     public function testIsReadableReturnsFalseWhenStreamIsDetached()
@@ -262,14 +264,15 @@ class StreamTest extends TestCase
         $this->assertFalse($stream->isReadable());
     }
 
-    public function testReadReturnsEmptyStringWhenStreamIsDetached()
+    public function testReadRaisesExceptionWhenStreamIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'phly');
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'r');
         $stream = new Stream($resource);
         $stream->detach();
-        $this->assertEquals('', $stream->read(4096));
+        $this->setExpectedException('RuntimeException', 'No resource');
+        $stream->read(4096);
     }
 
     public function testReadReturnsEmptyStringWhenAtEndOfFile()

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -1,0 +1,220 @@
+<?php
+namespace PhlyTest\Http;
+
+use Phly\Http\Stream;
+use Phly\Http\UploadedFile;
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+
+class UploadedFileTest extends TestCase
+{
+    protected $tmpFile;
+
+    public function setUp()
+    {
+        $this->tmpfile = null;
+    }
+
+    public function tearDown()
+    {
+        if (is_scalar($this->tmpFile) && file_exists($this->tmpFile)) {
+            unlink($this->tmpFile);
+        }
+    }
+
+    public function invalidStreams()
+    {
+        return [
+            'null'         => [null],
+            'true'         => [true],
+            'false'        => [false],
+            'int'          => [1],
+            'float'        => [1.1],
+            /* Have not figured out a valid way to test an invalid path yet; null byte injection
+             * appears to get caught by fopen()
+            'invalid-path' => [ ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) ? '[:]' : 'foo' . chr(0) ],
+             */
+            'array'        => [['filename']],
+            'object'       => [(object) ['filename']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidStreams
+     */
+    public function testRaisesExceptionOnInvalidStreamOrFile($streamOrFile)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new UploadedFile($streamOrFile, 0, UPLOAD_ERR_OK);
+    }
+
+    public function invalidSizes()
+    {
+        return [
+            'null'   => [null],
+            'true'   => [true],
+            'false'  => [false],
+            'float'  => [1.1],
+            'string' => ['1'],
+            'array'  => [[1]],
+            'object' => [(object) [1]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSizes
+     */
+    public function testRaisesExceptionOnInvalidSize($size)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'size');
+        new UploadedFile(fopen('php://temp', 'wb+'), $size, UPLOAD_ERR_OK);
+    }
+
+    public function invalidErrorStatuses()
+    {
+        return [
+            'null'     => [null],
+            'true'     => [true],
+            'false'    => [false],
+            'float'    => [1.1],
+            'string'   => ['1'],
+            'array'    => [[1]],
+            'object'   => [(object) [1]],
+            'negative' => [-1],
+            'too-big'  => [9],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidErrorStatuses
+     */
+    public function testRaisesExceptionOnInvalidErrorStatus($status)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'status');
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, $status);
+    }
+
+    public function invalidFilenamesAndMediaTypes()
+    {
+        return [
+            'true'   => [true],
+            'false'  => [false],
+            'int'    => [1],
+            'float'  => [1.1],
+            'array'  => [['string']],
+            'object' => [(object) ['string']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidFilenamesAndMediaTypes
+     */
+    public function testRaisesExceptionOnInvalidClientFilename($filename)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'filename');
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, $filename);
+    }
+
+    /**
+     * @dataProvider invalidFilenamesAndMediaTypes
+     */
+    public function testRaisesExceptionOnInvalidClientMediaType($mediaType)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'media type');
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'foobar.baz', $mediaType);
+    }
+
+    public function testGetStreamReturnsOriginalStreamObject()
+    {
+        $stream = new Stream('php://temp');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+        $this->assertSame($stream, $upload->getStream());
+    }
+
+    public function testGetStreamReturnsWrappedPhpStream()
+    {
+        $stream = fopen('php://temp', 'wb+');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+        $uploadStream = $upload->getStream()->detach();
+        $this->assertSame($stream, $uploadStream);
+    }
+
+    public function testGetStreamReturnsStreamForFile()
+    {
+        $this->tmpFile = $stream = tempnam(sys_get_temp_dir(), 'phly');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+        $uploadStream = $upload->getStream();
+        $r = new ReflectionProperty($uploadStream, 'stream');
+        $r->setAccessible(true);
+        $this->assertSame($stream, $r->getValue($uploadStream));
+    }
+
+    public function testMovesFileToDesignatedPath()
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
+        $upload->move($to);
+        $this->assertTrue(file_exists($to));
+        $contents = file_get_contents($to);
+        $this->assertEquals($stream->__toString(), $contents);
+    }
+
+    public function invalidMovePaths()
+    {
+        return [
+            'null'   => [null],
+            'true'   => [true],
+            'false'  => [false],
+            'int'    => [1],
+            'float'  => [1.1],
+            'empty'  => [''],
+            'array'  => [['filename']],
+            'object' => [(object) ['filename']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMovePaths
+     */
+    public function testMoveRaisesExceptionForInvalidPath($path)
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->tmpFile = $path;
+        $this->setExpectedException('InvalidArgumentException', 'path');
+        $upload->move($path);
+    }
+
+    public function testMoveCannotBeCalledMoreThanOnce()
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
+        $upload->move($to);
+        $this->assertTrue(file_exists($to));
+
+        $this->setExpectedException('RuntimeException', 'moved');
+        $upload->move($to);
+    }
+
+    public function testCannotRetrieveStreamAfterMove()
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
+        $upload->move($to);
+        $this->assertTrue(file_exists($to));
+
+        $this->setExpectedException('RuntimeException', 'moved');
+        $upload->getStream();
+    }
+}

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -208,29 +208,29 @@ class UriTest extends TestCase
         $this->assertEquals($url, (string) $uri);
     }
 
-    public function testSettingEmptyPathOnAbsoluteUriIsEquivalentToSettingRootPath()
+    public function testSettingEmptyPathOnAbsoluteUriReturnsAnEmptyPath()
     {
         $uri = new Uri('http://example.com/foo');
         $new = $uri->withPath('');
-        $this->assertEquals('/', $new->getPath());
+        $this->assertEquals('', $new->getPath());
     }
 
-    public function testStringRepresentationOfAbsoluteUriWithNoPathNormalizesPath()
+    public function testStringRepresentationOfAbsoluteUriWithNoPathSetsAnEmptyPath()
     {
         $uri = new Uri('http://example.com');
-        $this->assertEquals('http://example.com/', (string) $uri);
+        $this->assertEquals('http://example.com', (string) $uri);
     }
 
-    public function testEmptyPathOnOriginFormIsEquivalentToRootPath()
+    public function testEmptyPathOnOriginFormRemainsAnEmptyPath()
     {
         $uri = new Uri('?foo=bar');
-        $this->assertEquals('/', $uri->getPath());
+        $this->assertEquals('', $uri->getPath());
     }
 
-    public function testStringRepresentationOfOriginFormWithNoPathNormalizesPath()
+    public function testStringRepresentationOfOriginFormWithNoPathRetainsEmptyPath()
     {
         $uri = new Uri('?foo=bar');
-        $this->assertEquals('/?foo=bar', (string) $uri);
+        $this->assertEquals('?foo=bar', (string) $uri);
     }
 
     public function invalidConstructorUris()
@@ -292,11 +292,18 @@ class UriTest extends TestCase
         $uri->withScheme($scheme);
     }
 
-    public function testPathIsPrefixedWithSlashIfSetWithoutOne()
+    public function testPathIsNotPrefixedWithSlashIfSetWithoutOne()
     {
         $uri = new Uri('http://example.com');
         $new = $uri->withPath('foo/bar');
-        $this->assertEquals('/foo/bar', $new->getPath());
+        $this->assertEquals('foo/bar', $new->getPath());
+    }
+
+    public function testPathNotSlashPrefixedIsEmittedWithSlashDelimiterWhenUriIsCastToString()
+    {
+        $uri = new Uri('http://example.com');
+        $new = $uri->withPath('foo/bar');
+        $this->assertEquals('http://example.com/foo/bar', $new->__toString());
     }
 
     public function testStripsQueryPrefixIfPresent()


### PR DESCRIPTION
This pull request updates phly/http to the `0.10.*` version of the PSR-7 specification.

For a list of updates in that version, please [read my write-up](https://gistlog.co/weierophinney/8479b78e9ddcc9a16d9d).

In particular, this version:

- Adds `Phly\Http\UploadedFile`.
- Updates the various header retrieval methods in `Phly\Http\MessageTrait` to follow the new signatures.
- Updates `Phly\Http\Stream` to raise exceptions for error conditions.
- Updates `Phly\Http\ServerRequestFactory` to manipulate the `$_FILES` superglobal and normalize it to a tree of `UploadedFile` instances.
- Updates `Phly\Http\ServerRequest` to define `getUploadedFiles()` and `withUploadedFiles()`, and to remove `getFileParams()`.
- Adds the `$preserveHost` parameter to `Phly\Http\Uri`.