### PR TITLE
method refactoring

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -173,11 +173,11 @@ class ServerRequest implements ServerRequestInterface
      */
     public function getAttribute($attribute, $default = null)
     {
-        if (! array_key_exists($attribute, $this->attributes)) {
-            return $default;
+        if (isset($this->attributes[$attribute])) {
+            return $this->attributes[$attribute];
         }
 
-        return $this->attributes[$attribute];
+        return $default;
     }
 
     /**


### PR DESCRIPTION
isset is a bit faster than array_key_exists.

the difference is what you get when a key exists and the corresponding value is null.
```php
//if ($this->attributes['somekey'] === null)
// $defaultValue = 'something';
// 1) array_key_exists => getAttribute('somekey', $defaultValue) => null
// 2) isset            => getAttribute('somekey', $defaultValue) => 'something'
```
when i use this pattern i always assume i want to get some not null default value if the real value is null.