### PR TITLE
Sync phly/http with psr/http-message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.13.0 - TBD
+
+This release is BACKWARDS IN-COMPATIBLE with previous releases. 
+
+psr/http-message 0.11.0 renames the method
+`Psr\Http\UploadedFileInterface::move()` to `moveTo()`, which presents a
+backwards compatibility break.
+
+### Added
+
+- `Phly\Http\UploadedFile::moveTo()`, which allows moving an uploaded file
+  to a given path as represented by a valid PHP stream/filename.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `Phly\Http\UploadedFile::move()`, which was replaced with the
+  `moveTo()` method.
+
+### Fixed
+
+- `Phly\Http\Response::getReasonPhrase()` now *always* returns a string, even in
+  cases where the reason phrase is undefined (in which case it will be an
+  empty string).
+- `Phly\Http\Response::withStatus()` now defines the default value of the
+  `$reasonPhrase` argument as an empty string.
+
 ## 0.12.0 - 2015-04-14
 
 This release is BACKWARDS IN-COMPATIBLE with previous releases. This is in large

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "psr/http-message": "^0.10"
+    "psr/http-message": "^0.11.0"
   },
   "require-dev": {
     "phpunit/PHPUnit": "3.7.*",

--- a/src/Response.php
+++ b/src/Response.php
@@ -87,9 +87,9 @@ class Response implements ResponseInterface
     );
 
     /**
-     * @var null|string
+     * @var string
      */
-    private $reasonPhrase;
+    private $reasonPhrase = '';
 
     /**
      * @var int
@@ -147,7 +147,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withStatus($code, $reasonPhrase = null)
+    public function withStatus($code, $reasonPhrase = '')
     {
         $this->validateStatus($code);
         $new = clone $this;

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -111,20 +111,20 @@ class UploadedFile implements UploadedFileInterface
      *
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
-     * @param string $path Path to which to move the uploaded file.
+     * @param string $targetPath Path to which to move the uploaded file.
      * @throws \InvalidArgumentException if the $path specified is invalid.
      * @throws \RuntimeException on any error during the move operation, or on
      *     the second or subsequent call to the method.
      */
-    public function move($path)
+    public function moveTo($targetPath)
     {
-        if (! is_string($path)) {
+        if (! is_string($targetPath)) {
             throw new InvalidArgumentException(
                 'Invalid path provided for move operation; must be a string'
             );
         }
 
-        if (empty($path)) {
+        if (empty($targetPath)) {
             throw new InvalidArgumentException(
                 'Invalid path provided for move operation; must be a non-empty string'
             );
@@ -138,11 +138,11 @@ class UploadedFile implements UploadedFileInterface
         switch (true) {
             case (empty($sapi) || 0 === strpos($sapi, 'cli') || ! $this->file):
                 // Non-SAPI environment, or no filename present
-                $this->writeFile($path);
+                $this->writeFile($targetPath);
                 break;
             default:
                 // SAPI environment, with file present
-                if (false === move_uploaded_file($this->file, $path)) {
+                if (false === move_uploaded_file($this->file, $targetPath)) {
                     throw new RuntimeException('Error occurred while moving uploaded file');
                 }
                 break;

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -141,4 +141,11 @@ class ResponseTest extends TestCase
         $response = new Response('php://memory', null, $headers);
         $this->assertEquals($expected, $response->getHeaders());
     }
+
+    public function testReasonPhraseCanBeEmpty()
+    {
+        $response = $this->response->withStatus(599);
+        $this->assertInternalType('string', $response->getReasonPhrase());
+        $this->assertEmpty($response->getReasonPhrase());
+    }
 }

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -156,7 +156,7 @@ class UploadedFileTest extends TestCase
         $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
 
         $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
-        $upload->move($to);
+        $upload->moveTo($to);
         $this->assertTrue(file_exists($to));
         $contents = file_get_contents($to);
         $this->assertEquals($stream->__toString(), $contents);
@@ -187,7 +187,7 @@ class UploadedFileTest extends TestCase
 
         $this->tmpFile = $path;
         $this->setExpectedException('InvalidArgumentException', 'path');
-        $upload->move($path);
+        $upload->moveTo($path);
     }
 
     public function testMoveCannotBeCalledMoreThanOnce()
@@ -197,11 +197,11 @@ class UploadedFileTest extends TestCase
         $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
 
         $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
-        $upload->move($to);
+        $upload->moveTo($to);
         $this->assertTrue(file_exists($to));
 
         $this->setExpectedException('RuntimeException', 'moved');
-        $upload->move($to);
+        $upload->moveTo($to);
     }
 
     public function testCannotRetrieveStreamAfterMove()
@@ -211,7 +211,7 @@ class UploadedFileTest extends TestCase
         $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
 
         $this->tmpFile = $to = tempnam(sys_get_temp_dir(), 'phly');
-        $upload->move($to);
+        $upload->moveTo($to);
         $this->assertTrue(file_exists($to));
 
         $this->setExpectedException('RuntimeException', 'moved');


### PR DESCRIPTION
We're finishing the second review of PSR-7; this patch syncs phly/http with the changes introduced during review. There were only two substantive changes:

- `UploadedFileInterface::move()` was renamed to `moveTo()`.
- The reason phrase in the `ResponseInterface` is now _always_ a string, even when undefined.