### PR TITLE
Ensure headers are not open to CRLF vectors

### DIFF
--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Phly\Http;
+
+use InvalidArgumentException;
+
+/**
+ * Provide security tools around HTTP headers to prevent common injection vectors.
+ *
+ * Code is largely lifted from the Zend\Http\Header\HeaderValue implementation in
+ * Zend Framework, released with the copyright and license below.
+ *
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+final class HeaderSecurity
+{
+    /**
+     * Private constructor; non-instantiable.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Filter a header value
+     *
+     * Ensures CRLF header injection vectors are filtered.
+     *
+     * Per RFC 7230, only VISIBLE ASCII characters, spaces, and horizontal
+     * tabs are allowed in values; header continuations MUST consist of
+     * a single CRLF sequence followed by a space or horizontal tab.
+     *
+     * This method filters any values not allowed from the string, and is
+     * lossy.
+     *
+     * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     * @param string $value
+     * @return string
+     */
+    public static function filter($value)
+    {
+        $value  = (string) $value;
+        $length = strlen($value);
+        $string = '';
+        for ($i = 0; $i < $length; $i += 1) {
+            $ascii = ord($value[$i]);
+
+            // Detect continuation sequences
+            if ($ascii === 13) {
+                $lf = ord($value[$i + 1]);
+                $ws = ord($value[$i + 2]);
+                if ($lf === 10 && in_array($ws, [9, 32], true)) {
+                    $string .= $value[$i] . $value[$i + 1];
+                    $i += 1;
+                }
+
+                continue;
+            }
+
+            // Non-visible, non-whitespace characters
+            // 9 === horizontal tab
+            // 32-126, 128-254 === visible
+            // 127 === DEL
+            // 255 === null byte
+            if (($ascii < 32 && $ascii !== 9)
+                || $ascii === 127
+                || $ascii > 254
+            ) {
+                continue;
+            }
+
+            $string .= $value[$i];
+        }
+
+        return $string;
+    }
+
+    /**
+     * Validate a header value.
+     *
+     * Per RFC 7230, only VISIBLE ASCII characters, spaces, and horizontal
+     * tabs are allowed in values; header continuations MUST consist of
+     * a single CRLF sequence followed by a space or horizontal tab.
+     *
+     * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     * @param string $value
+     * @return bool
+     */
+    public static function isValid($value)
+    {
+        $value  = (string) $value;
+
+        // Look for:
+        // \n not preceded by \r, OR
+        // \r not followed by \n, OR
+        // \r\n not followed by space or horizontal tab; these are all CRLF attacks
+        if (preg_match("#(?:(?:(?<!\r)\n)|(?:\r(?!\n))|(?:\r\n(?![ \t])))#", $value)) {
+            return false;
+        }
+
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i += 1) {
+            $ascii = ord($value[$i]);
+
+            // Non-visible, non-whitespace characters
+            // 9 === horizontal tab
+            // 10 === line feed
+            // 13 === carriage return
+            // 32-126, 128-254 === visible
+            // 127 === DEL
+            // 255 === null byte
+            if (($ascii < 32 && ! in_array($ascii, [9, 10, 13], true))
+                || $ascii === 127
+                || $ascii > 254
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert a header value is valid.
+     *
+     * @param string $value
+     * @throws InvalidArgumentException for invalid values
+     */
+    public static function assertValid($value)
+    {
+        if (! self::isValid($value)) {
+            throw new InvalidArgumentException('Invalid header value');
+        }
+    }
+}

--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -133,4 +133,18 @@ final class HeaderSecurity
             throw new InvalidArgumentException('Invalid header value');
         }
     }
+    
+    /**
+     * Assert whether or not a header name is valid.
+     * 
+     * @see http://tools.ietf.org/html/rfc7230#section-3.2
+     * @param mixed $name 
+     * @throws InvalidArgumentException
+     */
+    public static function assertValidName($name)
+    {
+        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/', $name)) {
+            throw new InvalidArgumentException('Invalid header name');
+        }
+    }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -192,6 +192,9 @@ trait MessageTrait
             );
         }
 
+        self::assertValidHeaderName($header);
+        self::assertValidHeaderValue($value);
+
         $normalized = strtolower($header);
 
         $new = clone $this;
@@ -229,6 +232,9 @@ trait MessageTrait
                 'Invalid header value; must be a string or array of strings'
             );
         }
+
+        self::assertValidHeaderName($header);
+        self::assertValidHeaderValue($value);
 
         if (! $this->hasHeader($header)) {
             return $this->withHeader($header, $value);
@@ -355,5 +361,31 @@ trait MessageTrait
             return false;
         }
         return $carry;
+    }
+
+    /**
+     * Assert that the provided header name is valid.
+     * 
+     * @see http://tools.ietf.org/html/rfc7230#section-3.2
+     * @param string $name 
+     * @throws InvalidArgumentException
+     */
+    private static function assertValidHeaderName($name)
+    {
+        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/', $name)) {
+            throw new InvalidArgumentException('Invalid header name');
+        }
+    }
+
+    /**
+     * Assert that the provided header values are valid.
+     * 
+     * @see http://tools.ietf.org/html/rfc7230#section-3.2
+     * @param string[] $values
+     * @throws InvalidArgumentException
+     */
+    private static function assertValidHeaderValue(array $values)
+    {
+        array_walk($values, __NAMESPACE__ . '\HeaderSecurity::assertValid');
     }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -192,7 +192,7 @@ trait MessageTrait
             );
         }
 
-        self::assertValidHeaderName($header);
+        HeaderSecurity::assertValidName($header);
         self::assertValidHeaderValue($value);
 
         $normalized = strtolower($header);
@@ -233,7 +233,7 @@ trait MessageTrait
             );
         }
 
-        self::assertValidHeaderName($header);
+        HeaderSecurity::assertValidName($header);
         self::assertValidHeaderValue($value);
 
         if (! $this->hasHeader($header)) {
@@ -361,20 +361,6 @@ trait MessageTrait
             return false;
         }
         return $carry;
-    }
-
-    /**
-     * Assert that the provided header name is valid.
-     * 
-     * @see http://tools.ietf.org/html/rfc7230#section-3.2
-     * @param string $name 
-     * @throws InvalidArgumentException
-     */
-    private static function assertValidHeaderName($name)
-    {
-        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/', $name)) {
-            throw new InvalidArgumentException('Invalid header name');
-        }
     }
 
     /**

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -89,7 +89,9 @@ trait RequestTrait
         $this->uri    = $uri;
         $this->stream = ($body instanceof StreamInterface) ? $body : new Stream($body, 'r');
 
-        list($this->headerNames, $this->headers) = $this->filterHeaders($headers);
+        list($this->headerNames, $headers) = $this->filterHeaders($headers);
+        $this->assertHeaders($headers);
+        $this->headers = $headers;
     }
 
     /**
@@ -296,5 +298,19 @@ trait RequestTrait
         $host  = $this->uri->getHost();
         $host .= $this->uri->getPort() ? ':' . $this->uri->getPort() : '';
         return $host;
+    }
+
+    /**
+     * Ensure header names and values are valid.
+     * 
+     * @param array $headers 
+     * @throws InvalidArgumentException
+     */
+    private function assertHeaders(array $headers)
+    {
+        foreach ($headers as $name => $headerValues) {
+            HeaderSecurity::assertValidName($name);
+            array_walk($headerValues, __NAMESPACE__ . '\HeaderSecurity::assertValid');
+        }
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -119,7 +119,9 @@ class Response implements ResponseInterface
         $this->stream     = ($body instanceof StreamInterface) ? $body : new Stream($body, 'wb+');
         $this->statusCode = $status ? (int) $status : 200;
 
-        list($this->headerNames, $this->headers) = $this->filterHeaders($headers);
+        list($this->headerNames, $headers) = $this->filterHeaders($headers);
+        $this->assertHeaders($headers);
+        $this->headers = $headers;
     }
 
     /**
@@ -173,6 +175,20 @@ class Response implements ResponseInterface
                 'Invalid status code "%s"; must be an integer between 100 and 599, inclusive',
                 (is_scalar($code) ? $code : gettype($code))
             ));
+        }
+    }
+
+    /**
+     * Ensure header names and values are valid.
+     * 
+     * @param array $headers 
+     * @throws InvalidArgumentException
+     */
+    private function assertHeaders(array $headers)
+    {
+        foreach ($headers as $name => $headerValues) {
+            HeaderSecurity::assertValidName($name);
+            array_walk($headerValues, __NAMESPACE__ . '\HeaderSecurity::assertValid');
         }
     }
 }

--- a/test/HeaderSecurityTest.php
+++ b/test/HeaderSecurityTest.php
@@ -1,0 +1,98 @@
+<?php
+namespace PhlyTest\Http;
+
+use Phly\Http\HeaderSecurity;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests for Phly\Http\HeaderSecurity.
+ *
+ * Tests are largely derived from those for Zend\Http\Header\HeaderValue in
+ * Zend Framework, released with the copyright and license below.
+ *
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+class HeaderSecurityTest extends TestCase
+{
+    /**
+     * Data for filter value
+     */
+    public function getFilterValues()
+    {
+        return array(
+            array("This is a\n test", "This is a test"),
+            array("This is a\r test", "This is a test"),
+            array("This is a\n\r test", "This is a test"),
+            array("This is a\r\n  test", "This is a\r\n  test"),
+            array("This is a \r\ntest", "This is a test"),
+            array("This is a \r\n\n test", "This is a  test"),
+            array("This is a\n\n test", "This is a test"),
+            array("This is a\r\r test", "This is a test"),
+            array("This is a \r\r\n test", "This is a \r\n test"),
+            array("This is a \r\n\r\ntest", "This is a test"),
+            array("This is a \r\n\n\r\n test", "This is a \r\n test")
+        );
+    }
+
+    /**
+     * @dataProvider getFilterValues
+     * @group ZF2015-04
+     */
+    public function testFiltersValuesPerRfc7230($value, $expected)
+    {
+        $this->assertEquals($expected, HeaderSecurity::filter($value));
+    }
+
+    public function validateValues()
+    {
+        return array(
+            array("This is a\n test", 'assertFalse'),
+            array("This is a\r test", 'assertFalse'),
+            array("This is a\n\r test", 'assertFalse'),
+            array("This is a\r\n  test", 'assertTrue'),
+            array("This is a \r\ntest", 'assertFalse'),
+            array("This is a \r\n\n test", 'assertFalse'),
+            array("This is a\n\n test", 'assertFalse'),
+            array("This is a\r\r test", 'assertFalse'),
+            array("This is a \r\r\n test", 'assertFalse'),
+            array("This is a \r\n\r\ntest", 'assertFalse'),
+            array("This is a \r\n\n\r\n test", 'assertFalse')
+        );
+    }
+
+    /**
+     * @dataProvider validateValues
+     * @group ZF2015-04
+     */
+    public function testValidatesValuesPerRfc7230($value, $assertion)
+    {
+        $this->{$assertion}(HeaderSecurity::isValid($value));
+    }
+
+    public function assertValues()
+    {
+        return array(
+            array("This is a\n test"),
+            array("This is a\r test"),
+            array("This is a\n\r test"),
+            array("This is a \r\ntest"),
+            array("This is a \r\n\n test"),
+            array("This is a\n\n test"),
+            array("This is a\r\r test"),
+            array("This is a \r\r\n test"),
+            array("This is a \r\n\r\ntest"),
+            array("This is a \r\n\n\r\n test")
+        );
+    }
+
+    /**
+     * @dataProvider assertValues
+     * @group ZF2015-04
+     */
+    public function testAssertValidRaisesExceptionForInvalidValue($value)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        HeaderSecurity::assertValid($value);
+    }
+}

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -382,4 +382,32 @@ class RequestTest extends TestCase
 
         $this->assertEquals('www.example.com:10081', $new->getHeaderLine('Host'));
     }
+
+    public function headersWithInjectionVectors()
+    {
+        return [
+            'name-with-cr'           => ["X-Foo\r-Bar", 'value'],
+            'name-with-lf'           => ["X-Foo\n-Bar", 'value'],
+            'name-with-crlf'         => ["X-Foo\r\n-Bar", 'value'],
+            'name-with-2crlf'        => ["X-Foo\r\n\r\n-Bar", 'value'],
+            'value-with-cr'          => ['X-Foo-Bar', "value\rinjection"],
+            'value-with-lf'          => ['X-Foo-Bar', "value\ninjection"],
+            'value-with-crlf'        => ['X-Foo-Bar', "value\r\ninjection"],
+            'value-with-2crlf'       => ['X-Foo-Bar', "value\r\n\r\ninjection"],
+            'array-value-with-cr'    => ['X-Foo-Bar', ["value\rinjection"]],
+            'array-value-with-lf'    => ['X-Foo-Bar', ["value\ninjection"]],
+            'array-value-with-crlf'  => ['X-Foo-Bar', ["value\r\ninjection"]],
+            'array-value-with-2crlf' => ['X-Foo-Bar', ["value\r\n\r\ninjection"]],
+        ];
+    }
+
+    /**
+     * @group ZF2015-04
+     * @dataProvider headersWithInjectionVectors
+     */
+    public function testConstructorRaisesExceptionForHeadersWithCRLFVectors($name, $value)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $request = new Request(null, null, 'php://memory', [$name =>  $value]);
+    }
 }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -148,4 +148,32 @@ class ResponseTest extends TestCase
         $this->assertInternalType('string', $response->getReasonPhrase());
         $this->assertEmpty($response->getReasonPhrase());
     }
+
+    public function headersWithInjectionVectors()
+    {
+        return [
+            'name-with-cr'           => ["X-Foo\r-Bar", 'value'],
+            'name-with-lf'           => ["X-Foo\n-Bar", 'value'],
+            'name-with-crlf'         => ["X-Foo\r\n-Bar", 'value'],
+            'name-with-2crlf'        => ["X-Foo\r\n\r\n-Bar", 'value'],
+            'value-with-cr'          => ['X-Foo-Bar', "value\rinjection"],
+            'value-with-lf'          => ['X-Foo-Bar', "value\ninjection"],
+            'value-with-crlf'        => ['X-Foo-Bar', "value\r\ninjection"],
+            'value-with-2crlf'       => ['X-Foo-Bar', "value\r\n\r\ninjection"],
+            'array-value-with-cr'    => ['X-Foo-Bar', ["value\rinjection"]],
+            'array-value-with-lf'    => ['X-Foo-Bar', ["value\ninjection"]],
+            'array-value-with-crlf'  => ['X-Foo-Bar', ["value\r\ninjection"]],
+            'array-value-with-2crlf' => ['X-Foo-Bar', ["value\r\n\r\ninjection"]],
+        ];
+    }
+
+    /**
+     * @group ZF2015-04
+     * @dataProvider headersWithInjectionVectors
+     */
+    public function testConstructorRaisesExceptionForHeadersWithCRLFVectors($name, $value)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $request = new Response('php://memory', 200, [$name =>  $value]);
+    }
 }


### PR DESCRIPTION
Zend Framework reported in [ZF2015-04](http://framework.zend.com/security/advisory/ZF2015-04) potential CRLF attack vectors in HTTP headers. This patch borrows code from ZF2 to protect against similar vectors in phly/http.

Introduced is a new class, `Phly\Http\HeaderSecurity`, with the following methods:

- `filter($value)`, which will filter a header value of any illegal characters or invalid continuation sequences.
- `isValid($value)`, which will indicate whether or not the value follows RFC 7230 specifications.
- `assertValid($value)`, which will raise an exception for an invalid value.

`MessageTrait` was updated to raise exceptions in the case of invalid header names or values being passed to `withHeader()` and `withAddedHeader()`. Both `RequestTrait::initialize()` and `Response::__construct()` were updated to validate headers passed to the constructor.