### PR TITLE
Adds virtual package to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "phpunit/PHPUnit": "3.7.*",
     "squizlabs/php_codesniffer": "1.5.*"
   },
+  "provide": {
+    "psr/http-message-implementation": "0.11"
+  },
   "autoload": {
     "psr-4": {
       "Phly\\Http\\": "src/"


### PR DESCRIPTION
Rationale: there are other implementations of this PSR. This allows developers to rely on an implementation of the PSR instead of a concrete package. Since this is considered to be the "first" implementation, it is a good place to start this practice.