### PR TITLE
Message serialization and response emitters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 vendor/
-composer.lock
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,36 @@ sudo: false
 
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
-
 matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env:
+        - EXECUTE_COVERAGE=true
+        - EXECUTE_CS_CHECK=true
+    - php: 7
+    - php: hhvm 
   allow_failures:
+    - php: 7
     - php: hhvm
+
+before_install:
+  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 before_script:
   - composer self-update
   - composer install --dev --prefer-source
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
-  - ./vendor/bin/phpcs --standard=PSR2 --ignore=test/Bootstrap.php src test
+  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
+  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then ./vendor/bin/phpunit ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs --standard=PSR2 --ignore=test/Bootstrap.php src test ; fi
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover ./test/coverage.clover
+  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
+  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then php ocular.phar code-coverage:upload --format=php-clover ./test/coverage.clover ; fi
 
 notifications:
   email: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.14.0 - TBD
+
+### Added
+
+- [#67](https://github.com/phly/http/pull/67) adds two new feature:
+  - Response emitters. `Phly\Http\Response\EmitterInterface` defines the
+    contract for emitters, with the single method `emit()`. A single
+    concrete emitter is provided, `Phly\Http\Response\SapiEmitter`.
+    `Phly\Http\Server` now composes an emitter, using the `SapiEmitter` by
+    default.
+  - Serializers. `Phly\Http\Request\Serializer` and
+    `Phly\Http\Response\Serializer` provide the following static methods:
+    - `fromString($message)` will parse the given message string and return the
+      appropriate message instance.
+    - `fromStream(Psr\Http\Message\StreamInterface $stream)` will parse the
+      given message stream and return the appropriate message instance.
+    - `toString(Psr\Http\Message\RequestInterface|Psr\Http\MessageResponseInterface $message)`
+      will return a string representation of the given message instance.
+- A `CONTRIBUTING.md` file was added.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Documentation was updated to ensure all components of the package are
+  documented. Documentation that duplicates PSR-7 was removed.
+
 ## 0.13.3 - 2015-05-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+Contributing
+============
+
+Issues may be reported to https://github.com/phly/http/issues.
+Patches may be submitted via pull request to https://github.com/phly/http/pulls.
+
+
+If you are submitting a pull request, please follow these guidelines:
+
+- Please write unit tests for any features or bugfixes you have. I will not and
+  can not read your mind; demonstrate with code what you are attempting.
+- Please run unit tests before opening a pull request. You can do so by
+  executing `./vendor/bin/phpunit` from the project root. This will help you
+  identify whether or not your change affects other areas of the code.
+- Please run CodeSniffer before opening a pull request, and correct any issues:
+  `./vendor/bin/phpcs --standard=PSR2 --ignore=test/Bootstrap.php src test`.
+  `phpcs` provides a tool for fixing most errors as well:
+  `./vendor/bin/phpcbf --standard=PSR2 --ignore=test/Bootstrap.php src test`.
+  If you run the tool and it fixes issues, make sure you commit them!
+- Use a branch from your fork, not your master branch. This will help ensure you
+  submit only commits specific to the bugfix or feature you are submitting.
+  Feel free to continue pushing changes to that branch as you improve your
+  patch.
+- Keep your branch up-to-date with master (where "upstream" is a remote
+  representing this repository):
+  ```console
+  $ git fetch upstream
+  $ git rebase upstream/master
+  ```
+  If you rebase, make sure you force push your changes to your own branch (where
+  "origin" is your own remote):
+  ```console
+  $ git push -f origin <your branch>:<your branch>
+  ```

--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ $ composer require phly/http
 
 - `psr/http-message`, which defines interfaces for HTTP messages, including requests and responses. `phly/http` provides implementations of each of these.
 
-Contributing
-------------
-
-- Please write unit tests for any features or bug reports you have.
-- Please run unit tests before opening a pull request. You can do so using `./vendor/bin/phpunit`.
-- Please run CodeSniffer before opening a pull request, and correct any issues. Use the following to run it: `./vendor/bin/phpcs --standard=PSR2 --ignore=test/Bootstrap.php src test`.
-
 Usage
 -----
 
@@ -213,23 +206,8 @@ class Request
         $body = 'php://memory',
         array $headers = []
     );
-    public function getRequestTarget();
-    public function getMethod();
-    public function getUri();
-    public function getProtocolVersion();
-    public function getBody();
-    public function hasHeader($header);
-    public function getHeader($header);
-    public function getHeaderLines($header);
-    public function getHeaders();
-    public function withRequestTarget($requestTarget);
-    public function withMethod($method);
-    public function withUri(Psr\Http\Message\UriInterface $uri);
-    public function withProtocolVersion($version);
-    public function withHeader($header, $value);
-    public function withAddedHeader($header, $value);
-    public function withoutHeader($header);
-    public function withBody(Psr\Http\Message\StreamableInterface $body);
+
+    // See psr/http-message's RequestInterface for other methods
 }
 ```
 
@@ -250,41 +228,12 @@ class ServerRequest
         $body = 'php://input',
         array $headers = []
     );
-    public function getRequestTarget();
-    public function getMethod();
-    public function getUri();
-    public function getProtocolVersion();
-    public function hasHeader($header);
-    public function getHeader($header);
-    public function getHeaderLines($header);
-    public function getHeaders();
-    public function getCookieParams();
-    public function getQueryParams();
-    public function getBody();
-    public function getParsedBody();
-    public function getAttribute($attribute, $default = NULL);
-    public function getAttributes();
-    public function getServerParams();
-    public function getFileParams();
-    public function hasHeader($header);
 
-    public function withRequestTarget($requestTarget);
-    public function withMethod($method);
-    public function withUri(Psr\Http\Message\UriInterface $uri);
-    public function withProtocolVersion($version);
-    public function withHeader($header, $value);
-    public function withAddedHeader($header, $value);
-    public function withoutHeader($header);
-    public function withCookieParams(array $cookies);
-    public function withQueryParams(array $query);
-    public function withBody(Psr\Http\Message\StreamableInterface $stream);
-    public function withParsedBody(array $params);
-    public function withAttribute($attribute, $value);
-    public function withoutAttribute($attribute);
+    // See psr/http-message's ServerRequestInterface for other methods.
 }
 ```
 
-The `ServerRequest` is immutable. Any methods that would change state -- those prefixed with `with` and `without` -- all return a new instance with the changes requested. Two input sources, server and file parameters, are considered completely immutable, however, as they cannot be recalculated, and, rather, are the sources for other values.
+The `ServerRequest` is immutable. Any methods that would change state -- those prefixed with `with` and `without` -- all return a new instance with the changes requested. Server parameters are considered completely immutable, however, as they cannot be recalculated, and, rather, is a source for other values.
 
 ### Response Message
 
@@ -298,20 +247,8 @@ class Response
         $statusCode = 200,
         array $headers = []
     );
-    public function getProtocolVersion();
-    public function getStatusCode();
-    public function getReasonPhrase();
-    public function getHeader($header);
-    public function getHeaderLines($header);
-    public function getHeaders();
-    public function getBody();
-    public function hasHeader($header);
-    public function withProtocolVersion($version);
-    public function withStatus($code, $reasonPhrase = NULL);
-    public function withHeader($header, $value);
-    public function withAddedHeader($header, $value);
-    public function withoutHeader($header);
-    public function withBody(Psr\Http\Message\StreamableInterface $body);
+
+    // See psr/http-message's ResponseInterface for other methods
 }
 ```
 
@@ -346,22 +283,8 @@ $request = RequestFactory::fromGlobals(
 class Uri
 {
     public function __construct($uri = '');
-    public function getScheme();
-    public function getAuthority();
-    public function getUserInfo();
-    public function getHost();
-    public function getPort();
-    public function getPath();
-    public function getQuery();
-    public function getFragment();
-    public function withScheme($scheme);
-    public function withUserInfo($user, $password = null);
-    public function withHost($host);
-    public function withPort($port);
-    public function withPath($path);
-    public function withQuery($query);
-    public function withFragment($fragment);
-    public function __toString();
+
+    // See psr/http-message's UriInterface for other methods.
 }
 ```
 
@@ -369,7 +292,7 @@ Like the various message objects, URIs are immutable. Any methods that would cha
 
 ### Stream
 
-`Phly\Http\Stream` is an implementation of `Psr\Http\Message\StreamableInterface`, and provides a number of facilities around manipulating the composed PHP stream resource. The constructor accepts a stream, which may be either:
+`Phly\Http\Stream` is an implementation of `Psr\Http\Message\StreamInterface`, and provides a number of facilities around manipulating the composed PHP stream resource. The constructor accepts a stream, which may be either:
 
 - a stream identifier; e.g., `php://input`, a filename, etc.
 - a PHP stream resource
@@ -379,6 +302,12 @@ If a stream identifier is provided, an optional second parameter may be provided
 `ServerRequest` objects by default use a `php://input` stream set to read-only; `Response` objects by default use a `php://memory` with a mode of `wb+`, allowing binary read/write access.
 
 In most cases, you will not interact with the Stream object directly.
+
+### UploadedFile
+
+`Phly\Http\UploadedFile` is an implementation of `Psr\Http\Message\UploadedFileInterface`, and provides abstraction around a single uploaded file, including behavior for interacting with it as a stream or moving it to a filesystem location.
+
+In most cases, you will only use the methods defined in the `UploadedFileInterface`.
 
 ### Server
 
@@ -405,6 +334,7 @@ class Server
         Psr\Http\Message\ServerRequestInterface $request,
         Psr\Http\Message\ResponseInterface $response = null
     );
+    public function setEmitter(Response\EmitterInterface $emitter);
     public function listen(callable $finalHandler = null);
 }
 ```
@@ -412,3 +342,17 @@ class Server
 You can create an instance of the `Server` using any of the constructor, `createServer()`, or `createServerFromRequest()` methods. If you wish to use the default request and response implementations, `createServer($middleware, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES)` is the recommended option, as this method will also marshal the `ServerRequest` object based on the PHP request environment.  If you wish to use your own implementations, pass them to the constructor or `createServerFromRequest()` method (the latter will create a default `Response` instance if you omit it).
 
 `listen()` executes the callback. If a `$finalHandler` is provided, it will be passed as the third argument to the `$callback` registered with the server.
+
+## Emitting responses
+
+If you are using a non-SAPI PHP implementation and wish to use the `Server` class, or if you do not want to use the `Server` implementation but want to emit a response, this package provides an interface, `Phly\Http\Response\EmitterInterface`, defining a method `emit()` for emitting the response. A single implementation is currently available, `Phly\Http\Response\SapiEmitter`, which will use the native PHP functions `header()` and `echo` in order to emit the response. If you are using a non-SAPI implementation, you will need to create your own `EmitterInterface` implementation.
+
+## Serialization
+
+At times, it's useful to either create a string representation of a message (serialization), or to cast a string or stream message to an object (deserialization). This package provides features for this in `Phly\Http\Request\Serializer` and `Phly\Http\Response\Serializer`; each provides the following static methods:
+
+- `fromString($message)` will create either a `Request` or `Response` instance (based on the serializer used) from the string message.
+- `fromStream(Psr\Http\Message\StreamInterface $stream)` will create either a `Request` or `Response` instance (based on the serializer used) from the provided stream.
+- `toString(Psr\Http\Message\RequestInterface|Psr\Http\Message\ResponseInterface $message)` will create either a string from the provided message.
+
+The deserialization methods (`from*()`) will raise exceptions if errors occur while parsing the message. The serialization methods (`toString()`) will raise exceptions if required data for serialization is not present in the message instance.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "phpunit/PHPUnit": "3.7.*",
-    "squizlabs/php_codesniffer": "1.5.*"
+    "squizlabs/php_codesniffer": "~2.0"
   },
   "provide": {
     "psr/http-message-implementation": "~1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
       "PhlyTest\\Http\\": "test/"
     },
     "files": [
-      "test/TestAsset/Functions.php"
+      "test/TestAsset/Functions.php",
+      "test/TestAsset/SapiResponse.php"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,562 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "5098c6d64204f3cf6142594337f4e96d",
+    "packages": [
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "1.2.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": ">=1.3.0@stable",
+                "phpunit/php-text-template": ">=1.2.0@stable",
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-09-02 10:13:14"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-04-02 05:19:05"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Text/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2014-01-30 17:20:04"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2013-08-02 07:42:54"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2014-03-03 05:10:30"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "3.7.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.1",
+                "phpunit/php-timer": "~1.0",
+                "phpunit/phpunit-mock-objects": "~1.2",
+                "symfony/yaml": "~2.0"
+            },
+            "require-dev": {
+                "pear-pear.php.net/pear": "1.9.4"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "composer/bin/phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-10-17 09:04:17"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": ">=1.1.1@stable"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2013-01-13 10:24:48"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "e96d8579fbed0c95ecf2a0501ec4f307a4aa6404"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e96d8579fbed0c95ecf2a0501ec4f307a4aa6404",
+                "reference": "e96d8579fbed0c95ecf2a0501ec4f307a4aa6404",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2015-04-28 23:28:20"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.6.7",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.4.8"
+    },
+    "platform-dev": []
+}

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -1,0 +1,151 @@
+<?php
+namespace Phly\Http;
+
+use Psr\Http\Message\StreamInterface;
+use UnexpectedValueException;
+
+/**
+ * Provides base functionality for request and response de/serialization
+ * strategies, including functionality for retrieving a line at a time from
+ * the message, splitting headers from the body, and serializing headers.
+ */
+abstract class AbstractSerializer
+{
+    const CR  = "\r";
+    const EOL = "\r\n";
+    const LF  = "\n";
+
+    /**
+     * Retrieve a single line from the stream.
+     *
+     * Retrieves a line from the stream; a line is defined as a sequence of
+     * characters ending in a CRLF sequence.
+     *
+     * @param StreamInterface $stream
+     * @return string
+     * @throws UnexpectedValueException if the sequence contains a CR or LF in
+     *     isolation, or ends in a CR.
+     */
+    protected static function getLine(StreamInterface $stream)
+    {
+        $line    = '';
+        $crFound = false;
+        while (! $stream->eof()) {
+            $char = $stream->read(1);
+
+            if ($crFound && $char === self::LF) {
+                $crFound = false;
+                break;
+            }
+
+            // CR NOT followed by LF
+            if ($crFound && $char !== self::LF) {
+                throw new UnexpectedValueException('Unexpected carriage return detected');
+            }
+
+            // LF in isolation
+            if (! $crFound && $char === self::LF) {
+                throw new UnexpectedValueException('Unexpected line feed detected');
+            }
+
+            // CR found; do not append
+            if ($char === self::CR) {
+                $crFound = true;
+                continue;
+            }
+
+            // Any other character: append
+            $line .= $char;
+        }
+
+        // CR found at end of stream
+        if ($crFound) {
+            throw new UnexpectedValueException("Unexpected end of headers");
+        }
+
+        return $line;
+    }
+
+    /**
+     * Split the stream into headers and body content.
+     *
+     * Returns an array containing two elements
+     *
+     * - The first is an array of headers
+     * - The second is a StreamInterface containing the body content
+     *
+     * @param StreamInterface $stream
+     * @return array
+     * @throws UnexpectedValueException For invalid headers.
+     */
+    protected static function splitStream(StreamInterface $stream)
+    {
+        $headers       = [];
+        $currentHeader = false;
+
+        while ($line = self::getLine($stream)) {
+            if (preg_match(';^(?P<name>[!#$%&\'*+.^_`\|~0-9a-zA-Z-]+):(?P<value>.*)$;', $line, $matches)) {
+                $currentHeader = $matches['name'];
+                if (! isset($headers[$currentHeader])) {
+                    $headers[$currentHeader] = [];
+                }
+                $headers[$currentHeader][] = ltrim($matches['value']);
+                continue;
+            }
+
+            if (! $currentHeader) {
+                throw new UnexpectedValueException('Invalid header detected');
+            }
+
+            if (! preg_match('#^[ \t]#', $line)) {
+                throw new UnexpectedValueException('Invalid header continuation');
+            }
+
+            // Append continuation to last header value found
+            $value = array_pop($headers[$currentHeader]);
+            $headers[$currentHeader][] = $value . ltrim($line);
+        }
+
+        $body = new Stream('php://temp', 'wb+');
+        if (! $stream->eof()) {
+            while ($data = $stream->read(4096)) {
+                $body->write($data);
+            }
+            $body->rewind();
+        }
+
+        return [$headers, $body];
+    }
+
+    /**
+     * Serialize headers to string values.
+     *
+     * @param array $headers
+     * @return string
+     */
+    protected static function serializeHeaders(array $headers)
+    {
+        $lines = [];
+        foreach ($headers as $header => $values) {
+            $normalized = self::filterHeader($header);
+            foreach ($values as $value) {
+                $lines[] = sprintf('%s: %s', $normalized, $value);
+            }
+        }
+
+        return implode("\r\n", $lines);
+    }
+
+    /**
+     * Filter a header name to wordcase
+     *
+     * @param string $header
+     * @return string
+     */
+    protected static function filterHeader($header)
+    {
+        $filtered = str_replace('-', ' ', $header);
+        $filtered = ucwords($filtered);
+        return str_replace(' ', '-', $filtered);
+    }
+}

--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -136,9 +136,9 @@ final class HeaderSecurity
     
     /**
      * Assert whether or not a header name is valid.
-     * 
+     *
      * @see http://tools.ietf.org/html/rfc7230#section-3.2
-     * @param mixed $name 
+     * @param mixed $name
      * @throws InvalidArgumentException
      */
     public static function assertValidName($name)

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -365,7 +365,7 @@ trait MessageTrait
 
     /**
      * Assert that the provided header values are valid.
-     * 
+     *
      * @see http://tools.ietf.org/html/rfc7230#section-3.2
      * @param string[] $values
      * @throws InvalidArgumentException

--- a/src/PhpInputStream.php
+++ b/src/PhpInputStream.php
@@ -1,7 +1,6 @@
 <?php
 namespace Phly\Http;
 
-
 /**
  * Caching version of php://input
  */

--- a/src/Request/Serializer.php
+++ b/src/Request/Serializer.php
@@ -1,0 +1,138 @@
+<?php
+namespace Phly\Http\Request;
+
+use Phly\Http\AbstractSerializer;
+use Phly\Http\Request;
+use Phly\Http\Stream;
+use Phly\Http\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use UnexpectedValueException;
+
+/**
+ * Serialize (cast to string) or deserialize (cast string to Request) messages.
+ *
+ * This class provides functionality for serializing a RequestInterface instance
+ * to a string, as well as the reverse operation of creating a Request instance
+ * from a string/stream representing a message.
+ */
+final class Serializer extends AbstractSerializer
+{
+    /**
+     * Deserialize a request string to a request instance.
+     *
+     * Internally, casts the message to a stream and invokes fromStream().
+     *
+     * @param string $message
+     * @return Request
+     * @throws UnexpectedValueException when errors occur parsing the message.
+     */
+    public static function fromString($message)
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write($message);
+        return self::fromStream($stream);
+    }
+
+    /**
+     * Deserialize a request stream to a request instance.
+     *
+     * @param StreamInterface $stream
+     * @return Request
+     * @throws UnexpectedValueException when errors occur parsing the message.
+     */
+    public static function fromStream(StreamInterface $stream)
+    {
+        if (! $stream->isReadable() && ! $stream->isSeekable()) {
+            throw new InvalidArgumentException('Message stream must be both readable and seekable');
+        }
+
+        $stream->rewind();
+
+        list($method, $requestTarget, $version) = self::getRequestLine($stream);
+        $uri = self::createUriFromRequestTarget($requestTarget);
+
+        list($headers, $body) = self::splitStream($stream);
+
+        return (new Request($uri, $method, $body, $headers))
+            ->withProtocolVersion($version)
+            ->withRequestTarget($requestTarget);
+    }
+
+    /**
+     * Serialize a request message to a string.
+     *
+     * @param RequestInterface $request
+     * @return string
+     */
+    public static function toString(RequestInterface $request)
+    {
+        $headers = self::serializeHeaders($request->getHeaders());
+        $body    = (string) $request->getBody();
+        $format  = '%s %s HTTP/%s%s%s';
+
+        if (! empty($headers)) {
+            $headers = "\r\n" . $headers;
+        }
+        if (! empty($body)) {
+            $headers .= "\r\n\r\n";
+        }
+
+        return sprintf(
+            $format,
+            $request->getMethod(),
+            $request->getRequestTarget(),
+            $request->getProtocolVersion(),
+            $headers,
+            $body
+        );
+    }
+
+    /**
+     * Retrieve the components of the request line.
+     *
+     * Retrieves the first line of the stream and parses it, raising an
+     * exception if it does not follow specifications; if valid, returns a list
+     * with the method, target, and version, in that order.
+     *
+     * @param StreamInterface $stream
+     * @return array
+     */
+    private static function getRequestLine(StreamInterface $stream)
+    {
+        $requestLine = self::getLine($stream);
+
+        if (! preg_match(
+            '#^(?P<method>[!\#$%&\'*+.^_`|~a-zA-Z0-9-]+) (?P<target>[^\s]+) HTTP/(?P<version>[1-9]\d*\.\d+)$#',
+            $requestLine,
+            $matches
+        )) {
+            throw new UnexpectedValueException('Invalid request line detected');
+        }
+
+        return [$matches['method'], $matches['target'], $matches['version']];
+    }
+
+    /**
+     * Create and return a Uri instance based on the provided request target.
+     *
+     * If the request target is of authority or asterisk form, an empty Uri
+     * instance is returned; otherwise, the value is used to create and return
+     * a new Uri instance.
+     *
+     * @param string $requestTarget
+     * @return Uri
+     */
+    private static function createUriFromRequestTarget($requestTarget)
+    {
+        if (preg_match('#^https?://#', $requestTarget)) {
+            return new Uri($requestTarget);
+        }
+
+        if (preg_match('#^(\*|[^/])#', $requestTarget)) {
+            return new Uri();
+        }
+
+        return new Uri($requestTarget);
+    }
+}

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -290,7 +290,7 @@ trait RequestTrait
 
     /**
      * Retrieve the host from the URI instance
-     * 
+     *
      * @return string
      */
     private function getHostFromUri()
@@ -302,8 +302,8 @@ trait RequestTrait
 
     /**
      * Ensure header names and values are valid.
-     * 
-     * @param array $headers 
+     *
+     * @param array $headers
      * @throws InvalidArgumentException
      */
     private function assertHeaders(array $headers)

--- a/src/Response.php
+++ b/src/Response.php
@@ -180,8 +180,8 @@ class Response implements ResponseInterface
 
     /**
      * Ensure header names and values are valid.
-     * 
-     * @param array $headers 
+     *
+     * @param array $headers
      * @throws InvalidArgumentException
      */
     private function assertHeaders(array $headers)

--- a/src/Response/EmitterInterface.php
+++ b/src/Response/EmitterInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace Phly\Http\Response;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface EmitterInterface
+{
+    /**
+     * Emit a response.
+     *
+     * Emits a response, including status line, headers, and the message body,
+     * according to the environment.
+     *
+     * Implementations of this method may be written in such a way as to have
+     * side effects, such as usage of header() or pushing output to the
+     * output buffer.
+     *
+     * Implementations MAY raise exceptions if they are unable to emit the
+     * response; e.g., if headers have already been sent.
+     * 
+     * @param ResponseInterface $response 
+     */
+    public function emit(ResponseInterface $response);
+}

--- a/src/Response/EmitterInterface.php
+++ b/src/Response/EmitterInterface.php
@@ -17,8 +17,8 @@ interface EmitterInterface
      *
      * Implementations MAY raise exceptions if they are unable to emit the
      * response; e.g., if headers have already been sent.
-     * 
-     * @param ResponseInterface $response 
+     *
+     * @param ResponseInterface $response
      */
     public function emit(ResponseInterface $response);
 }

--- a/src/Response/SapiEmitter.php
+++ b/src/Response/SapiEmitter.php
@@ -11,8 +11,8 @@ class SapiEmitter implements EmitterInterface
      *
      * Emits the status line and headers via the header() function, and the
      * body content via the output buffer.
-     * 
-     * @param ResponseInterface $response 
+     *
+     * @param ResponseInterface $response
      * @param null|int $maxBufferLevel Maximum output buffering level to unwrap.
      */
     public function emit(ResponseInterface $response, $maxBufferLevel = null)
@@ -29,10 +29,10 @@ class SapiEmitter implements EmitterInterface
     /**
      * Emit the status line.
      *
-     * Emits the status line using the protocol version and status code from 
+     * Emits the status line using the protocol version and status code from
      * the response; if a reason phrase is availble, it, too, is emitted.
-     * 
-     * @param ResponseInterface $response 
+     *
+     * @param ResponseInterface $response
      */
     private function emitStatusLine(ResponseInterface $response)
     {
@@ -52,8 +52,8 @@ class SapiEmitter implements EmitterInterface
      * is an array with multiple values, ensures that each is sent
      * in such a way as to create aggregate headers (instead of replace
      * the previous).
-     * 
-     * @param ResponseInterface $response 
+     *
+     * @param ResponseInterface $response
      */
     private function emitHeaders(ResponseInterface $response)
     {
@@ -76,8 +76,8 @@ class SapiEmitter implements EmitterInterface
      *
      * Loops through the output buffer, flushing each, before emitting
      * the response body using `echo()`.
-     * 
-     * @param ResponseInterface $response 
+     *
+     * @param ResponseInterface $response
      */
     private function emitBody(ResponseInterface $response, $maxBufferLevel)
     {

--- a/src/Response/SapiEmitter.php
+++ b/src/Response/SapiEmitter.php
@@ -1,0 +1,107 @@
+<?php
+namespace Phly\Http\Response;
+
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class SapiEmitter implements EmitterInterface
+{
+    /**
+     * Emits a response for a PHP SAPI environment.
+     *
+     * Emits the status line and headers via the header() function, and the
+     * body content via the output buffer.
+     * 
+     * @param ResponseInterface $response 
+     * @param null|int $maxBufferLevel Maximum output buffering level to unwrap.
+     */
+    public function emit(ResponseInterface $response, $maxBufferLevel = null)
+    {
+        if (headers_sent()) {
+            throw new RuntimeException('Unable to emit response; headers already sent');
+        }
+
+        $this->emitStatusLine($response);
+        $this->emitHeaders($response);
+        $this->emitBody($response, $maxBufferLevel);
+    }
+
+    /**
+     * Emit the status line.
+     *
+     * Emits the status line using the protocol version and status code from 
+     * the response; if a reason phrase is availble, it, too, is emitted.
+     * 
+     * @param ResponseInterface $response 
+     */
+    private function emitStatusLine(ResponseInterface $response)
+    {
+        $reasonPhrase = $response->getReasonPhrase();
+        header(sprintf(
+            'HTTP/%s %d%s',
+            $response->getProtocolVersion(),
+            $response->getStatusCode(),
+            ($reasonPhrase ? ' ' . $reasonPhrase : '')
+        ));
+    }
+
+    /**
+     * Emit response headers.
+     *
+     * Loops through each header, emitting each; if the header value
+     * is an array with multiple values, ensures that each is sent
+     * in such a way as to create aggregate headers (instead of replace
+     * the previous).
+     * 
+     * @param ResponseInterface $response 
+     */
+    private function emitHeaders(ResponseInterface $response)
+    {
+        foreach ($response->getHeaders() as $header => $values) {
+            $name  = $this->filterHeader($header);
+            $first = true;
+            foreach ($values as $value) {
+                header(sprintf(
+                    '%s: %s',
+                    $name,
+                    $value
+                ), $first);
+                $first = false;
+            }
+        }
+    }
+
+    /**
+     * Emit the message body.
+     *
+     * Loops through the output buffer, flushing each, before emitting
+     * the response body using `echo()`.
+     * 
+     * @param ResponseInterface $response 
+     */
+    private function emitBody(ResponseInterface $response, $maxBufferLevel)
+    {
+        if (null === $maxBufferLevel) {
+            $maxBufferLevel = ob_get_level();
+        }
+
+        while (ob_get_level() > $maxBufferLevel) {
+            ob_end_flush();
+        }
+
+        echo $response->getBody();
+    }
+
+    /**
+     * Filter a header name to wordcase
+     *
+     * @param string $header
+     * @return string
+     */
+    private function filterHeader($header)
+    {
+        $filtered = str_replace('-', ' ', $header);
+        $filtered = ucwords($filtered);
+        return str_replace(' ', '-', $filtered);
+    }
+}

--- a/src/Response/Serializer.php
+++ b/src/Response/Serializer.php
@@ -1,0 +1,103 @@
+<?php
+namespace Phly\Http\Response;
+
+use InvalidArgumentException;
+use Phly\Http\AbstractSerializer;
+use Phly\Http\Response;
+use Phly\Http\Stream;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use UnexpectedValueException;
+
+final class Serializer extends AbstractSerializer
+{
+    /**
+     * Deserialize a response string to a response instance.
+     *
+     * @param string $message
+     * @return Response
+     * @throws UnexpectedValueException when errors occur parsing the message.
+     */
+    public static function fromString($message)
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write($message);
+        return static::fromStream($stream);
+    }
+
+    /**
+     * Parse a response from a stream.
+     *
+     * @param StreamInterface $stream
+     * @return ResponseInterface
+     * @throws InvalidArgumentException when the stream is not readable.
+     * @throws UnexpectedValueException when errors occur parsing the message.
+     */
+    public static function fromStream(StreamInterface $stream)
+    {
+        if (! $stream->isReadable() && ! $stream->isSeekable()) {
+            throw new InvalidArgumentException('Message stream must be both readable and seekable');
+        }
+
+        $stream->rewind();
+
+        list($version, $status, $reasonPhrase) = self::getStatusLine($stream);
+        list($headers, $body)                  = self::splitStream($stream);
+
+        return (new Response($body, $status, $headers))
+            ->withProtocolVersion($version)
+            ->withStatus($status, $reasonPhrase);
+    }
+
+    /**
+     * Create a string representation of a response.
+     *
+     * @param ResponseInterface $response
+     * @return string
+     */
+    public static function toString(ResponseInterface $response)
+    {
+        $reasonPhrase = $response->getReasonPhrase();
+        $headers      = self::serializeHeaders($response->getHeaders());
+        $body         = (string) $response->getBody();
+        $format       = 'HTTP/%s %d%s%s%s';
+
+        if (! empty($headers)) {
+            $headers = "\r\n" . $headers;
+        }
+        if (! empty($body)) {
+            $headers .= "\r\n\r\n";
+        }
+
+        return sprintf(
+            $format,
+            $response->getProtocolVersion(),
+            $response->getStatusCode(),
+            ($reasonPhrase ? ' ' . $reasonPhrase : ''),
+            $headers,
+            $body
+        );
+    }
+
+    /**
+     * Retrieve the status line for the message.
+     *
+     * @param StreamInterface $stream
+     * @return array Array with three elements: 0 => version, 1 => status, 2 => reason
+     * @throws UnexpectedValueException if line is malformed
+     */
+    private static function getStatusLine(StreamInterface $stream)
+    {
+        $line = self::getLine($stream);
+
+        if (! preg_match(
+            '#^HTTP/(?P<version>[1-9]\d*\.\d) (?P<status>[1-5]\d{2})(\s+(?P<reason>.+))?$#',
+            $line,
+            $matches
+        )) {
+            throw new UnexpectedValueException('No status line detected');
+        }
+
+        return [$matches['version'], $matches['status'], isset($matches['reason']) ? $matches['reason'] : ''];
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -172,7 +172,7 @@ class Server
      * Retrieve the current response emitter.
      *
      * If none has been registered, lazy-loads a Response\SapiEmitter.
-     * 
+     *
      * @return Response\EmitterInterface
      */
     private function getEmitter()

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -19,7 +19,7 @@ abstract class ServerRequestFactory
 {
     /**
      * Function to use to get apache request headers; present only to simplify mocking.
-     * 
+     *
      * @var callable
      */
     private static $apacheRequestHeaders = 'apache_request_headers';
@@ -452,8 +452,8 @@ abstract class ServerRequestFactory
      *
      * Loops through all nested files and returns a normalized array of
      * UploadedFileInterface instances.
-     * 
-     * @param array $files 
+     *
+     * @param array $files
      * @return UploadedFileInterface[]
      */
     private static function normalizeNestedFileSpec(array $files)

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -88,9 +88,9 @@ class Stream implements StreamInterface
 
     /**
      * Attach a new stream/resource to the instance.
-     * 
-     * @param string|resource $resource 
-     * @param string $mode 
+     *
+     * @param string|resource $resource
+     * @param string $mode
      * @throws InvalidArgumentException for stream identifier that cannot be
      *     cast to a resource
      * @throws InvalidArgumentException for non-resource stream

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -193,8 +193,8 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * Write internal stream to given path
-     * 
-     * @param string $path 
+     *
+     * @param string $path
      */
     private function writeFile($path)
     {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -510,10 +510,10 @@ class Uri implements UriInterface
 
     /**
      * Filter a query string to ensure it is propertly encoded.
-     * 
+     *
      * Ensures that the values in the query string are properly urlencoded.
-     * 
-     * @param string $query 
+     *
+     * @param string $query
      * @return string
      */
     private function filterQuery($query)
@@ -541,8 +541,8 @@ class Uri implements UriInterface
 
     /**
      * Split a query value into a key/value tuple.
-     * 
-     * @param string $value 
+     *
+     * @param string $value
      * @return array A value with exactly two elements, key and value
      */
     private function splitQueryValue($value)
@@ -556,8 +556,8 @@ class Uri implements UriInterface
 
     /**
      * Filter a fragment value to ensure it is properly encoded.
-     * 
-     * @param null|string $fragment 
+     *
+     * @param null|string $fragment
      * @return string
      */
     private function filterFragment($fragment)

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -1,0 +1,263 @@
+<?php
+namespace PhlyTest\Http\Request;
+
+use Phly\Http\Request;
+use Phly\Http\Request\Serializer;
+use Phly\Http\Stream;
+use Phly\Http\Uri;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SerializerTest extends TestCase
+{
+    public function testSerializesBasicRequest()
+    {
+        $request = (new Request())
+            ->withMethod('GET')
+            ->withUri(new Uri('http://example.com/foo/bar?baz=bat'))
+            ->withAddedHeader('Accept', 'text/html');
+
+        $message = Serializer::toString($request);
+        $this->assertEquals(
+            "GET /foo/bar?baz=bat HTTP/1.1\r\nHost: example.com\r\nAccept: text/html",
+            $message
+        );
+    }
+
+    public function testSerializesRequestWithBody()
+    {
+        $body   = json_encode(['test' => 'value']);
+        $stream = new Stream('php://memory', 'wb+');
+        $stream->write($body);
+
+        $request = (new Request())
+            ->withMethod('POST')
+            ->withUri(new Uri('http://example.com/foo/bar'))
+            ->withAddedHeader('Accept', 'application/json')
+            ->withAddedHeader('Content-Type', 'application/json')
+            ->withBody($stream);
+
+        $message = Serializer::toString($request);
+        $this->assertContains("POST /foo/bar HTTP/1.1\r\n", $message);
+        $this->assertContains("\r\n\r\n" . $body, $message);
+    }
+
+    public function testSerializesMultipleHeadersCorrectly()
+    {
+        $request = (new Request())
+            ->withMethod('GET')
+            ->withUri(new Uri('http://example.com/foo/bar?baz=bat'))
+            ->withAddedHeader('X-Foo-Bar', 'Baz')
+            ->withAddedHeader('X-Foo-Bar', 'Bat');
+
+        $message = Serializer::toString($request);
+        $this->assertContains("X-Foo-Bar: Baz", $message);
+        $this->assertContains("X-Foo-Bar: Bat", $message);
+    }
+
+    public function originForms()
+    {
+        return [
+            'path-only'      => [
+                'GET /foo HTTP/1.1',
+                '/foo',
+                ['getPath' => '/foo'],
+            ],
+            'path-and-query' => [
+                'GET /foo?bar HTTP/1.1',
+                '/foo?bar',
+                ['getPath' => '/foo', 'getQuery' => 'bar'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider originForms
+     */
+    public function testCanDeserializeRequestWithOriginForm($line, $requestTarget, $expectations)
+    {
+        $message = $line . "\r\nX-Foo-Bar: Baz\r\n\r\nContent";
+        $request = Serializer::fromString($message);
+
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals($requestTarget, $request->getRequestTarget());
+
+        $uri = $request->getUri();
+        foreach ($expectations as $method => $expect) {
+            $this->assertEquals($expect, $uri->{$method}());
+        }
+    }
+
+    public function absoluteForms()
+    {
+        return [
+            'path-only'      => [
+                'GET http://example.com/foo HTTP/1.1',
+                'http://example.com/foo',
+                [
+                    'getScheme' => 'http',
+                    'getHost'   => 'example.com',
+                    'getPath'   => '/foo',
+                ],
+            ],
+            'path-and-query' => [
+                'GET http://example.com/foo?bar HTTP/1.1',
+                'http://example.com/foo?bar',
+                [
+                    'getScheme' => 'http',
+                    'getHost'   => 'example.com',
+                    'getPath'   => '/foo',
+                    'getQuery'  => 'bar',
+                ],
+            ],
+            'with-port'      => [
+                'GET http://example.com:8080/foo?bar HTTP/1.1',
+                'http://example.com:8080/foo?bar',
+                [
+                    'getScheme' => 'http',
+                    'getHost'   => 'example.com',
+                    'getPort'   => 8080,
+                    'getPath'   => '/foo',
+                    'getQuery'  => 'bar',
+                ],
+            ],
+            'with-authority' => [
+                'GET https://me:too@example.com:8080/foo?bar HTTP/1.1',
+                'https://me:too@example.com:8080/foo?bar',
+                [
+                    'getScheme'   => 'https',
+                    'getUserInfo' => 'me:too',
+                    'getHost'     => 'example.com',
+                    'getPort'     => 8080,
+                    'getPath'     => '/foo',
+                    'getQuery'    => 'bar',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider absoluteForms
+     */
+    public function testCanDeserializeRequestWithAbsoluteForm($line, $requestTarget, $expectations)
+    {
+        $message = $line . "\r\nX-Foo-Bar: Baz\r\n\r\nContent";
+        $request = Serializer::fromString($message);
+
+        $this->assertEquals('GET', $request->getMethod());
+
+        $this->assertEquals($requestTarget, $request->getRequestTarget());
+
+        $uri = $request->getUri();
+        foreach ($expectations as $method => $expect) {
+            $this->assertEquals($expect, $uri->{$method}());
+        }
+    }
+
+    public function testCanDeserializeRequestWithAuthorityForm()
+    {
+        $message = "CONNECT www.example.com:80 HTTP/1.1\r\nX-Foo-Bar: Baz";
+        $request = Serializer::fromString($message);
+        $this->assertEquals('CONNECT', $request->getMethod());
+        $this->assertEquals('www.example.com:80', $request->getRequestTarget());
+
+        $uri = $request->getUri();
+        $this->assertNotEquals('www.example.com', $uri->getHost());
+        $this->assertNotEquals(80, $uri->getPort());
+    }
+
+    public function testCanDeserializeRequestWithAsteriskForm()
+    {
+        $message = "OPTIONS * HTTP/1.1\r\nHost: www.example.com";
+        $request = Serializer::fromString($message);
+        $this->assertEquals('OPTIONS', $request->getMethod());
+        $this->assertEquals('*', $request->getRequestTarget());
+
+        $uri = $request->getUri();
+        $this->assertNotEquals('www.example.com', $uri->getHost());
+
+        $this->assertTrue($request->hasHeader('Host'));
+        $this->assertEquals('www.example.com', $request->getHeaderLine('Host'));
+    }
+
+    public function invalidRequestLines()
+    {
+        return [
+            'missing-method'   => ['/foo/bar HTTP/1.1'],
+            'missing-target'   => ['GET HTTP/1.1'],
+            'missing-protocol' => ['GET /foo/bar'],
+            'simply-malformed' => ['What is this mess?'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidRequestLines
+     */
+    public function testRaisesExceptionDuringDeserializationForInvalidRequestLine($line)
+    {
+        $message = $line . "\r\nX-Foo-Bar: Baz\r\n\r\nContent";
+        $this->setExpectedException('UnexpectedValueException');
+        Serializer::fromString($message);
+    }
+
+    public function testCanDeserializeResponseWithMultipleHeadersOfSameName()
+    {
+        $text = "POST /foo HTTP/1.0\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz\r\nX-Foo-Bar: Bat\r\n\r\nContent!";
+        $request = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertInstanceOf('Phly\Http\Request', $request);
+
+        $this->assertTrue($request->hasHeader('X-Foo-Bar'));
+        $values = $request->getHeader('X-Foo-Bar');
+        $this->assertEquals(['Baz', 'Bat'], $values);
+    }
+
+    public function headersWithContinuationLines()
+    {
+        return [
+            'space' => ["POST /foo HTTP/1.0\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n Bat\r\n\r\nContent!"],
+            'tab' => ["POST /foo HTTP/1.0\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n\tBat\r\n\r\nContent!"],
+        ];
+    }
+
+    /**
+     * @dataProvider headersWithContinuationLines
+     */
+    public function testCanDeserializeResponseWithHeaderContinuations($text)
+    {
+        $request = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertInstanceOf('Phly\Http\Request', $request);
+
+        $this->assertTrue($request->hasHeader('X-Foo-Bar'));
+        $this->assertEquals('Baz;Bat', $request->getHeaderLine('X-Foo-Bar'));
+    }
+
+    public function messagesWithInvalidHeaders()
+    {
+        return [
+            'invalid-name' => [
+                "GET /foo HTTP/1.1\r\nThi;-I()-Invalid: value",
+                'Invalid header detected'
+            ],
+            'invalid-format' => [
+                "POST /foo HTTP/1.1\r\nThis is not a header\r\n\r\nContent",
+                'Invalid header detected'
+            ],
+            'invalid-continuation' => [
+                "POST /foo HTTP/1.1\r\nX-Foo-Bar: Baz\r\nInvalid continuation\r\nContent",
+                'Invalid header continuation'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider messagesWithInvalidHeaders
+     */
+    public function testDeserializationRaisesExceptionForMalformedHeaders($message, $exceptionMessage)
+    {
+        $this->setExpectedException('UnexpectedValueException', $exceptionMessage);
+        $request = Serializer::fromString($message);
+    }
+}

--- a/test/Response/SapiEmitterTest.php
+++ b/test/Response/SapiEmitterTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace PhlyTest\Http\Response;
+
+use Phly\Http\HeaderStack;  // test asset
+use Phly\Http\Response;
+use Phly\Http\Response\SapiEmitter;
+use Phly\Http\SapiResponse; // test asset
+use Phly\Http\Stream;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SapiEmitterTest extends TestCase
+{
+    public function setUp()
+    {
+        HeaderStack::reset();
+        $this->emitter = new SapiEmitter();
+    }
+
+    public function tearDown()
+    {
+        HeaderStack::reset();
+    }
+
+    public function testEmitsResponseHeaders()
+    {
+        $response = (new Response())
+            ->withStatus(200)
+            ->withAddedHeader('Content-Type', 'text/plain');
+        $response->getBody()->write('Content!');
+
+        ob_start();
+        $this->emitter->emit($response);
+        ob_end_clean();
+        $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
+        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+    }
+
+    public function testEmitsMessageBody()
+    {
+        $response = (new Response())
+            ->withStatus(200)
+            ->withAddedHeader('Content-Type', 'text/plain');
+        $response->getBody()->write('Content!');
+
+        $this->expectOutputString('Content!');
+        $this->emitter->emit($response);
+    }
+}

--- a/test/Response/SerializerTest.php
+++ b/test/Response/SerializerTest.php
@@ -1,0 +1,179 @@
+<?php
+namespace PhlyTest\Http\Response;
+
+use Phly\Http\Response;
+use Phly\Http\Response\Serializer;
+use Phly\Http\Stream;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SerializerTest extends TestCase
+{
+    public function testSerializesBasicResponse()
+    {
+        $response = (new Response())
+            ->withStatus(200)
+            ->withAddedHeader('Content-Type', 'text/plain')
+            ->withAddedHeader('X-Foo-Bar', 'Baz');
+        $response->getBody()->write('Content!');
+
+        $message = Serializer::toString($response);
+        $this->assertEquals(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz\r\n\r\nContent!",
+            $message
+        );
+    }
+
+    public function testSerializesMultipleHeadersCorrectly()
+    {
+        $response = (new Response())
+            ->withStatus(204)
+            ->withAddedHeader('X-Foo-Bar', 'Baz')
+            ->withAddedHeader('X-Foo-Bar', 'Bat');
+
+        $message = Serializer::toString($response);
+        $this->assertContains("X-Foo-Bar: Baz", $message);
+        $this->assertContains("X-Foo-Bar: Bat", $message);
+    }
+
+    public function testOmitsReasonPhraseFromStatusLineIfEmpty()
+    {
+        $response = (new Response())
+            ->withStatus(299)
+            ->withAddedHeader('X-Foo-Bar', 'Baz');
+        $response->getBody()->write('Content!');
+
+        $message = Serializer::toString($response);
+        $this->assertContains("HTTP/1.1 299\r\n", $message);
+    }
+
+    public function testCanDeserializeBasicResponse()
+    {
+        $text = "HTTP/1.0 200 A-OK\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz\r\n\r\nContent!";
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertEquals('1.0', $response->getProtocolVersion());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('A-OK', $response->getReasonPhrase());
+
+        $this->assertTrue($response->hasHeader('Content-Type'));
+        $this->assertEquals('text/plain', $response->getHeaderLine('Content-Type'));
+
+        $this->assertTrue($response->hasHeader('X-Foo-Bar'));
+        $this->assertEquals('Baz', $response->getHeaderLine('X-Foo-Bar'));
+
+        $this->assertEquals('Content!', (string) $response->getBody());
+    }
+
+    public function testCanDeserializeResponseWithMultipleHeadersOfSameName()
+    {
+        $text = "HTTP/1.0 200 A-OK\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz\r\nX-Foo-Bar: Bat\r\n\r\nContent!";
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertTrue($response->hasHeader('X-Foo-Bar'));
+        $values = $response->getHeader('X-Foo-Bar');
+        $this->assertEquals(['Baz', 'Bat'], $values);
+    }
+
+    public function headersWithContinuationLines()
+    {
+        return [
+            'space' => ["HTTP/1.0 200 A-OK\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n Bat\r\n\r\nContent!"],
+            'tab' => ["HTTP/1.0 200 A-OK\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n\tBat\r\n\r\nContent!"],
+        ];
+    }
+
+    /**
+     * @dataProvider headersWithContinuationLines
+     */
+    public function testCanDeserializeResponseWithHeaderContinuations($text)
+    {
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertTrue($response->hasHeader('X-Foo-Bar'));
+        $this->assertEquals('Baz;Bat', $response->getHeaderLine('X-Foo-Bar'));
+    }
+
+    public function testCanDeserializeResponseWithoutBody()
+    {
+        $text = "HTTP/1.0 204\r\nX-Foo-Bar: Baz";
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertTrue($response->hasHeader('X-Foo-Bar'));
+        $this->assertEquals('Baz', $response->getHeaderLine('X-Foo-Bar'));
+
+        $body = $response->getBody()->getContents();
+        $this->assertEmpty($body);
+    }
+
+    public function testCanDeserializeResponseWithoutHeadersOrBody()
+    {
+        $text = "HTTP/1.0 204";
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertEmpty($response->getHeaders());
+        $body = $response->getBody()->getContents();
+        $this->assertEmpty($body);
+    }
+
+    public function testCanDeserializeResponseWithoutHeadersButContainingBody()
+    {
+        $text = "HTTP/1.0 204\r\n\r\nContent!";
+        $response = Serializer::fromString($text);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf('Phly\Http\Response', $response);
+
+        $this->assertEmpty($response->getHeaders());
+        $body = $response->getBody()->getContents();
+        $this->assertEquals('Content!', $body);
+    }
+
+    public function testDeserializationRaisesExceptionForInvalidStatusLine()
+    {
+        $text = "This is an invalid status line\r\nX-Foo-Bar: Baz\r\n\r\nContent!";
+        $this->setExpectedException('UnexpectedValueException', 'status line');
+        $response = Serializer::fromString($text);
+    }
+
+    public function messagesWithInvalidHeaders()
+    {
+        return [
+            'invalid-name' => [
+                "HTTP/1.1 204\r\nThi;-I()-Invalid: value",
+                'Invalid header detected'
+            ],
+            'invalid-format' => [
+                "HTTP/1.1 204\r\nThis is not a header\r\n\r\nContent",
+                'Invalid header detected'
+            ],
+            'invalid-continuation' => [
+                "HTTP/1.1 204\r\nX-Foo-Bar: Baz\r\nInvalid continuation\r\nContent",
+                'Invalid header continuation'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider messagesWithInvalidHeaders
+     */
+    public function testDeserializationRaisesExceptionForMalformedHeaders($message, $exceptionMessage)
+    {
+        $this->setExpectedException('UnexpectedValueException', $exceptionMessage);
+        $response = Serializer::fromString($message);
+    }
+}

--- a/test/TestAsset/Functions.php
+++ b/test/TestAsset/Functions.php
@@ -15,7 +15,6 @@
 
 namespace Phly\Http;
 
-
 /**
  * Store output artifacts
  */

--- a/test/TestAsset/Functions.php
+++ b/test/TestAsset/Functions.php
@@ -8,10 +8,8 @@
  * - headers_sent(): we want to always return false so that headers will be
  *   emitted, and we can test to see their values.
  * - header(): we want to aggregate calls to this function.
- * - printf(): we want to aggregate calls to this function as well; we cannot
- *   do the same with echo as it's a language construct, not a function.
  *
- * The Output class then aggregates that information for us, and the test
+ * The HeaderStack class then aggregates that information for us, and the test
  * harness resets the values pre and post test.
  */
 

--- a/test/TestAsset/SapiResponse.php
+++ b/test/TestAsset/SapiResponse.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file exists to allow overriding the various output-related functions
+ * in order to test what happens during the `Response\SapiEmitter::emit()` cycle.
+ *
+ * These functions include:
+ *
+ * - headers_sent(): we want to always return false so that headers will be
+ *   emitted, and we can test to see their values.
+ * - header(): we want to aggregate calls to this function.
+ *
+ * It pushes headers into the HeaderStack class defined in Functions.php.
+ */
+
+namespace Phly\Http\Response;
+
+use Phly\Http\HeaderStack;
+
+/**
+ * Have headers been sent?
+ *
+ * @return false
+ */
+function headers_sent()
+{
+    return false;
+}
+
+/**
+ * Emit a header, without creating actual output artifacts
+ *
+ * @param string $value
+ */
+function header($value)
+{
+    HeaderStack::push($value);
+}


### PR DESCRIPTION
This pull request is a response to #64. It implements the following:

- [x] Response emitter interface
- [x] SAPI implementation of the response emitter interface
- [x] Modification of `Server` to consume an emitter interface to emit a response.
- [x] Response serialization interface
- [x] Implementation of response serialization
- [x] Request serialization interface
- [x] Implementation of request serialization
- [x] Response deserialization (`fromString`)
- [x] Request deserialization (`fromString`)

These features should enable the following use cases:

- Ability to emit responses in SAPI environments without the use of `Server`.
- Ability to emit responses in non-SAPI environments via alternate emitter implementations.
- Ability to represent messages as strings (e.g., for logging or debugging purposes).
- Ability to accept messages as strings and cast them to appropriate instances.

## Usage

```php
// Serialization
$requestMessage = Phly\Http\Request\Serializer::toString($request);
$responseMessage = Phly\Http\Response\Serializer::toString($response);

// Deserialization
$request = Phly\Http\Request\Serializer::fromString($requestMessage);
$response = Phly\Http\Response\Serializer::fromString($responseMessage);

// Emit a response
(new Phly\Http\Response\SapiEmitter())->emit($response);
```

