### PR TITLE
Fix unit tests for Server to work under PHPUnit 4.6

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -14,14 +14,6 @@ use Psr\Http\Message\ResponseInterface;
 class Server
 {
     /**
-     * Level of output buffering at start of listen cycle; never flush more
-     * than this.
-     *
-     * @var int
-     */
-    private $bufferLevel;
-
-    /**
      * @var callable
      */
     private $callback;
@@ -159,13 +151,15 @@ class Server
     public function listen(callable $finalHandler = null)
     {
         $callback = $this->callback;
+
         ob_start();
-        $this->bufferLevel = ob_get_level();
+        $bufferLevel = ob_get_level();
+
         $response = $callback($this->request, $this->response, $finalHandler);
         if (! $response instanceof ResponseInterface) {
             $response = $this->response;
         }
-        $this->getEmitter()->emit($response);
+        $this->getEmitter()->emit($response, $bufferLevel);
     }
 
     /**

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -105,6 +105,7 @@ class ServerTest extends TestCase
 
         $this->expectOutputString('FOOBAR');
         $server->listen();
+        ob_end_flush();
 
         $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
         $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
@@ -130,6 +131,7 @@ class ServerTest extends TestCase
 
         $this->expectOutputString('FOOBAR');
         $server->listen();
+        ob_end_flush();
 
         $this->assertContains('HTTP/1.1 299', HeaderStack::stack());
         $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
@@ -154,6 +156,7 @@ class ServerTest extends TestCase
 
         $this->expectOutputString('100%');
         $server->listen();
+        ob_end_flush();
 
         $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
         $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
@@ -182,6 +185,7 @@ class ServerTest extends TestCase
         $server = Server::createServer($callback, $server, [], [], [], []);
 
         $server->listen();
+        ob_end_flush();
 
         $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
         $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
@@ -248,6 +252,7 @@ class ServerTest extends TestCase
             $this->response
         );
         $server->listen($final);
+        ob_end_flush();
         $this->assertTrue($invoked);
     }
 }


### PR DESCRIPTION
Per #71 , several `Server` unit tests are marked "risky" due to the fact that the output buffer is not flushed completely. This patch does the following:

- Updates those tests to call `ob_end_flush()` after the call to `listen()`. This is necessary as the emitter flushes output only to the `ob_level` at the time it was called.
- Modifies `Server` to pass the current `ob_level` to the emitter, and removes the stateful property for tracking the level (it's no longer necessary).